### PR TITLE
Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ if(EXFAT_RESIZE_BUILD_CLI)
     target_include_directories(
         exfat-resize
         PRIVATE
+            ${PROJECT_SOURCE_DIR}/lib
             ${PROJECT_SOURCE_DIR}/src
     )
 

--- a/lib/block_device.c
+++ b/lib/block_device.c
@@ -5,7 +5,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-static int supported_sector_size(uint32_t size)
+int exfat_resize_sector_size_is_supported(uint32_t size)
 {
 	return size >= 512 && size <= 4096 && (size & (size - 1)) == 0;
 }
@@ -15,7 +15,7 @@ enum exfat_resize_error exfat_resize_validate_block_device(
 {
 	if (device == NULL || device->read == NULL || device->write == NULL || device->sync == NULL)
 		return EXFAT_RESIZE_INVALID_DEVICE;
-	if (!supported_sector_size(device->sector_size) || device->sector_count == 0)
+	if (!exfat_resize_sector_size_is_supported(device->sector_size) || device->sector_count == 0)
 		return EXFAT_RESIZE_INVALID_DEVICE;
 	return EXFAT_RESIZE_SUCCESS;
 }

--- a/lib/block_device.h
+++ b/lib/block_device.h
@@ -13,6 +13,8 @@ struct exfat_resize_device_geometry {
 	uint64_t sector_count;
 };
 
+int exfat_resize_sector_size_is_supported(uint32_t size);
+
 enum exfat_resize_error exfat_resize_validate_block_device(
     const struct exfat_resize_block_device *device);
 

--- a/lib/geometry.c
+++ b/lib/geometry.c
@@ -119,13 +119,12 @@ enum exfat_resize_error exfat_resize_map_growth_cluster(const struct exfat_resiz
 
 	remaining_cluster_count = source->cluster_count - displaced_cluster_count;
 	source_index = source_cluster - 2;
+	/* Both branches produce a cluster in [2, source->cluster_count + 1]. */
 	if (source_index < displaced_cluster_count)
 		mapped_cluster = remaining_cluster_count + 2 + source_index;
 	else
 		mapped_cluster = 2 + source_index - displaced_cluster_count;
 
-	if (mapped_cluster > target->cluster_count + UINT32_C(1))
-		return EXFAT_RESIZE_OUT_OF_BOUNDS;
 	*target_cluster = mapped_cluster;
 	return EXFAT_RESIZE_SUCCESS;
 }

--- a/lib/resize.c
+++ b/lib/resize.c
@@ -334,9 +334,8 @@ static enum exfat_resize_error model_entry_for_source_cluster(
 	return EXFAT_RESIZE_SUCCESS;
 }
 
-static enum exfat_resize_error claim_allocation_stream(struct resize_context *context,
-    const struct exfat_resize_geometry *geometry,
-    const struct allocation_stream *stream)
+static enum exfat_resize_error claim_allocation_stream(
+    struct resize_context *context, const struct allocation_stream *stream)
 {
 	enum exfat_resize_error error;
 	uint32_t *model_entry;
@@ -349,18 +348,19 @@ static enum exfat_resize_error claim_allocation_stream(struct resize_context *co
 	error = stream_cluster_count(context, stream, &cluster_count);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
-	if (cluster_count > geometry->cluster_count)
+	if (cluster_count > context->source.cluster_count)
 		return EXFAT_RESIZE_INVALID_FILESYSTEM;
 	if (cluster_count == 0)
 		return stream->first_cluster == 0 ? EXFAT_RESIZE_SUCCESS : EXFAT_RESIZE_INVALID_FILESYSTEM;
-	if (!cluster_is_valid(geometry, stream->first_cluster))
+	if (!cluster_is_valid(&context->source, stream->first_cluster))
 		return EXFAT_RESIZE_INVALID_FILESYSTEM;
 
 	if (stream->no_fat_chain) {
 		int crosses =
 		    stream_crosses_mapping_boundary(context, stream->first_cluster, cluster_count);
 
-		if ((uint64_t)stream->first_cluster + cluster_count > (uint64_t)geometry->cluster_count + 2)
+		if ((uint64_t)stream->first_cluster + cluster_count >
+		    (uint64_t)context->source.cluster_count + 2)
 			return EXFAT_RESIZE_INVALID_FILESYSTEM;
 		for (index = 0; index < cluster_count; ++index) {
 			error = model_entry_for_source_cluster(
@@ -390,7 +390,8 @@ static enum exfat_resize_error claim_allocation_stream(struct resize_context *co
 			return error;
 		if (*model_entry != 0)
 			return EXFAT_RESIZE_INVALID_FILESYSTEM;
-		error = fat_get(context, geometry, cluster, SECTOR_CACHE_SOURCE_ALLOCATION_FAT, &next);
+		error =
+		    fat_get(context, &context->source, cluster, SECTOR_CACHE_SOURCE_ALLOCATION_FAT, &next);
 		if (error != EXFAT_RESIZE_SUCCESS)
 			return error;
 		if (index + 1 == cluster_count) {
@@ -399,7 +400,7 @@ static enum exfat_resize_error claim_allocation_stream(struct resize_context *co
 			*model_entry = EXFAT_FAT_END_OF_CHAIN;
 			return EXFAT_RESIZE_SUCCESS;
 		}
-		if (!cluster_is_valid(geometry, next))
+		if (!cluster_is_valid(&context->source, next))
 			return EXFAT_RESIZE_INVALID_FILESYSTEM;
 		error = map_cluster(context, next, &target_next);
 		if (error != EXFAT_RESIZE_SUCCESS)
@@ -480,20 +481,13 @@ static enum exfat_resize_error next_stream_cluster(
 	return EXFAT_RESIZE_SUCCESS;
 }
 
-static enum exfat_resize_error initialize_stream_cursor(struct resize_context *context,
+static enum exfat_resize_error initialize_stream_cursor(
     const struct exfat_resize_geometry *geometry,
     const struct allocation_stream *stream,
     enum sector_cache_index data_cache,
     enum sector_cache_index fat_cache,
-    uint64_t byte_offset,
     struct stream_cursor *cursor)
 {
-	enum exfat_resize_error error;
-	uint64_t clusters_to_skip;
-	uint64_t index;
-
-	if (!stream->root_directory && byte_offset > stream->data_length)
-		return EXFAT_RESIZE_OUT_OF_BOUNDS;
 	if (!cluster_is_valid(geometry, stream->first_cluster))
 		return EXFAT_RESIZE_INVALID_FILESYSTEM;
 
@@ -503,18 +497,7 @@ static enum exfat_resize_error initialize_stream_cursor(struct resize_context *c
 	cursor->data_cache = data_cache;
 	cursor->fat_cache = fat_cache;
 	cursor->current_cluster = stream->first_cluster;
-	cursor->remaining_bytes =
-	    stream->root_directory ? UINT64_MAX : stream->data_length - byte_offset;
-	clusters_to_skip = byte_offset / context->cluster_size;
-
-	for (index = 0; index < clusters_to_skip; ++index) {
-		error = next_stream_cluster(context, cursor);
-		if (error != EXFAT_RESIZE_SUCCESS)
-			return error;
-		if (cursor->exhausted)
-			return EXFAT_RESIZE_INVALID_FILESYSTEM;
-	}
-	cursor->cluster_offset = byte_offset % context->cluster_size;
+	cursor->remaining_bytes = stream->root_directory ? UINT64_MAX : stream->data_length;
 	if (cursor->remaining_bytes == 0)
 		cursor->exhausted = 1;
 	return EXFAT_RESIZE_SUCCESS;
@@ -743,7 +726,7 @@ static enum exfat_resize_error validate_entry_allocation(struct resize_context *
 	}
 	if (stream->no_fat_chain && stream->data_length == 0)
 		return EXFAT_RESIZE_INVALID_FILESYSTEM;
-	return claim_allocation_stream(context, &context->source, stream);
+	return claim_allocation_stream(context, stream);
 }
 
 static enum exfat_resize_error rewrite_entry_allocation(struct resize_context *context,
@@ -972,7 +955,7 @@ static enum exfat_resize_error scan_bitmap_entry(struct resize_context *context,
 	required_length = ((uint64_t)context->source.cluster_count + 7) / 8;
 	if (context->old_bitmap.data_length < required_length)
 		return EXFAT_RESIZE_INVALID_FILESYSTEM;
-	error = claim_allocation_stream(context, &context->source, &context->old_bitmap);
+	error = claim_allocation_stream(context, &context->old_bitmap);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
 	context->bitmap_location = *location;
@@ -1027,7 +1010,7 @@ static enum exfat_resize_error scan_upcase_entry(struct resize_context *context,
 	stream.no_fat_chain = 0;
 
 	if (mode == DIRECTORY_SCAN_VALIDATE)
-		return claim_allocation_stream(context, &context->source, &stream);
+		return claim_allocation_stream(context, &stream);
 	error = map_cluster(context, stream.first_cluster, &target_cluster);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
@@ -1069,11 +1052,11 @@ static enum exfat_resize_error scan_one_directory(struct resize_context *context
 	enum exfat_resize_error error;
 
 	if (mode == DIRECTORY_SCAN_REWRITE) {
-		error = initialize_stream_cursor(context, &context->target, directory,
-		    SECTOR_CACHE_TARGET_DIRECTORY_DATA, SECTOR_CACHE_TARGET_DIRECTORY_FAT, 0, &cursor);
+		error = initialize_stream_cursor(&context->target, directory,
+		    SECTOR_CACHE_TARGET_DIRECTORY_DATA, SECTOR_CACHE_TARGET_DIRECTORY_FAT, &cursor);
 	} else {
-		error = initialize_stream_cursor(context, &context->source, directory,
-		    SECTOR_CACHE_SOURCE_DIRECTORY_DATA, SECTOR_CACHE_SOURCE_DIRECTORY_FAT, 0, &cursor);
+		error = initialize_stream_cursor(&context->source, directory,
+		    SECTOR_CACHE_SOURCE_DIRECTORY_DATA, SECTOR_CACHE_SOURCE_DIRECTORY_FAT, &cursor);
 	}
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
@@ -1145,8 +1128,8 @@ static enum exfat_resize_error initialize_bitmap_reader(
     struct resize_context *context, struct bitmap_reader *reader)
 {
 	memset(reader, 0, sizeof(*reader));
-	return initialize_stream_cursor(context, &context->source, &context->old_bitmap,
-	    SECTOR_CACHE_SOURCE_BITMAP_DATA, SECTOR_CACHE_SOURCE_BITMAP_FAT, 0, &reader->cursor);
+	return initialize_stream_cursor(&context->source, &context->old_bitmap,
+	    SECTOR_CACHE_SOURCE_BITMAP_DATA, SECTOR_CACHE_SOURCE_BITMAP_FAT, &reader->cursor);
 }
 
 static enum exfat_resize_error read_old_bitmap_bit(

--- a/lib/sector_adapter.c
+++ b/lib/sector_adapter.c
@@ -2,13 +2,10 @@
 
 #include "sector_adapter.h"
 
+#include "block_device.h"
+
 #include <stddef.h>
 #include <stdint.h>
-
-static int supported_sector_size(uint32_t size)
-{
-	return size >= 512 && size <= 4096 && (size & (size - 1)) == 0;
-}
 
 static int adapt_transfer(const struct exfat_resize_sector_adapter *adapter,
     uint64_t first_sector,
@@ -68,7 +65,7 @@ enum exfat_resize_error exfat_resize_adapt_block_device(
 
 	if (adapter == NULL)
 		return EXFAT_RESIZE_INVALID_ARGUMENT;
-	if (!supported_sector_size(filesystem_sector_size) ||
+	if (!exfat_resize_sector_size_is_supported(filesystem_sector_size) ||
 	    filesystem_sector_size < source->sector_size ||
 	    filesystem_sector_size % source->sector_size != 0)
 		return EXFAT_RESIZE_UNSUPPORTED_SECTOR_MAPPING;

--- a/src/device.c
+++ b/src/device.c
@@ -6,6 +6,8 @@
 
 #include "device.h"
 
+#include "block_device.h"
+
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
@@ -156,7 +158,7 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 #endif
 	}
 
-	if (sector_size < 512 || sector_size > 4096 || (sector_size & (sector_size - 1)) != 0) {
+	if (!exfat_resize_sector_size_is_supported(sector_size)) {
 		(void)snprintf(
 		    error, error_size, "%s: unsupported logical sector size %" PRIu32, path, sector_size);
 		goto fail_after_open;

--- a/tests/cli/CMakeLists.txt
+++ b/tests/cli/CMakeLists.txt
@@ -10,6 +10,7 @@ function(exfat_resize_add_device_test target source test_name)
     target_include_directories(
         ${target}
         PRIVATE
+            ${PROJECT_SOURCE_DIR}/lib
             ${PROJECT_SOURCE_DIR}/src
     )
 

--- a/tests/library/support/memory_block_device.c
+++ b/tests/library/support/memory_block_device.c
@@ -114,8 +114,7 @@ static int copy_sectors(const struct memory_sector *source,
     size_t source_count,
     size_t sector_size,
     struct memory_sector **destination,
-    size_t *destination_count,
-    size_t *destination_capacity)
+    size_t *destination_count)
 {
 	struct memory_sector *copy = NULL;
 	size_t index;
@@ -140,7 +139,6 @@ static int copy_sectors(const struct memory_sector *source,
 	free_sectors(*destination, *destination_count);
 	*destination = copy;
 	*destination_count = source_count;
-	*destination_capacity = source_count;
 	return 0;
 }
 
@@ -291,12 +289,15 @@ void memory_block_device_clear_failure(struct memory_block_device *memory)
 int memory_block_device_make_durable(struct memory_block_device *memory)
 {
 	return copy_sectors(memory->sectors, memory->sector_count, memory->device.sector_size,
-	    &memory->durable_sectors, &memory->durable_sector_count, &memory->durable_sector_capacity);
+	    &memory->durable_sectors, &memory->durable_sector_count);
 }
 
 int memory_block_device_crash(struct memory_block_device *memory)
 {
-	return copy_sectors(memory->durable_sectors, memory->durable_sector_count,
-	    memory->device.sector_size, &memory->sectors, &memory->sector_count,
-	    &memory->sector_capacity);
+	int error = copy_sectors(memory->durable_sectors, memory->durable_sector_count,
+	    memory->device.sector_size, &memory->sectors, &memory->sector_count);
+
+	if (error == 0)
+		memory->sector_capacity = memory->sector_count;
+	return error;
 }

--- a/tests/library/support/memory_block_device.h
+++ b/tests/library/support/memory_block_device.h
@@ -31,7 +31,6 @@ struct memory_block_device {
 
 	struct memory_sector *durable_sectors;
 	size_t durable_sector_count;
-	size_t durable_sector_capacity;
 
 	struct memory_operation *operations;
 	size_t operation_count;

--- a/tests/library/unit/foundation_tests.c
+++ b/tests/library/unit/foundation_tests.c
@@ -184,6 +184,11 @@ static void test_device_geometry(void)
 	enum exfat_resize_error error;
 	size_t index;
 
+	for (index = 0; index < sizeof(valid_sizes) / sizeof(valid_sizes[0]); ++index)
+		CHECK(exfat_resize_sector_size_is_supported(valid_sizes[index]));
+	for (index = 0; index < sizeof(invalid_sizes) / sizeof(invalid_sizes[0]); ++index)
+		CHECK(!exfat_resize_sector_size_is_supported(invalid_sizes[index]));
+
 	memory_block_device_init(&memory, 512, 128);
 	device = memory.device;
 	for (index = 0; index < sizeof(valid_sizes) / sizeof(valid_sizes[0]); ++index) {
@@ -383,11 +388,13 @@ static void test_memory_block_device_durability(void)
 	unsigned char original[1024];
 	unsigned char replacement[1024];
 	unsigned char read_back[1024];
+	unsigned char added[512];
 
 	memset(original, 0x11, 512);
 	memset(original + 512, 0x22, 512);
 	memset(replacement, 0x33, 512);
 	memset(replacement + 512, 0x44, 512);
+	memset(added, 0x55, sizeof(added));
 
 	memory_block_device_init(&memory, 512, 4);
 	error = exfat_resize_block_device_write(&memory.device, 0, 2, original, sizeof(original));
@@ -408,6 +415,11 @@ static void test_memory_block_device_durability(void)
 	error = exfat_resize_block_device_read(&memory.device, 0, 2, read_back, sizeof(read_back));
 	CHECK(error == EXFAT_RESIZE_SUCCESS);
 	CHECK(memcmp(read_back, original, sizeof(read_back)) == 0);
+	error = exfat_resize_block_device_write(&memory.device, 2, 1, added, sizeof(added));
+	CHECK(error == EXFAT_RESIZE_SUCCESS);
+	error = exfat_resize_block_device_read(&memory.device, 2, 1, read_back, sizeof(added));
+	CHECK(error == EXFAT_RESIZE_SUCCESS);
+	CHECK(memcmp(read_back, added, sizeof(added)) == 0);
 
 	memory_block_device_clear_operations(&memory);
 	error = exfat_resize_block_device_write(&memory.device, 0, 2, replacement, sizeof(replacement));

--- a/tests/package/CMakeLists.txt
+++ b/tests/package/CMakeLists.txt
@@ -11,3 +11,9 @@ add_test(
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/install_test.cmake
 )
 set_tests_properties(package.install-documentation PROPERTIES LABELS package)
+
+add_test(
+    NAME package.version
+    COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/version.sh
+)
+set_tests_properties(package.version PROPERTIES LABELS package)

--- a/tests/package/version.sh
+++ b/tests/package/version.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+project_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+temporary=${TMPDIR:-/tmp}/exfat-resize-version-test.$$
+
+cleanup() {
+	rm -rf "$temporary"
+}
+
+expect_version() {
+	mode=$1
+	commit=$2
+	expected=$3
+
+	if [ "$mode" = checkout ]; then
+		actual=$(sh "$project_root/tools/version.sh" "$temporary/repository")
+	else
+		actual=$(sh "$project_root/tools/version.sh" --commit "$temporary/repository" "$commit")
+	fi
+	if [ "$actual" != "$expected" ]; then
+		echo "$mode version: expected '$expected', got '$actual'" >&2
+		exit 1
+	fi
+}
+
+expect_tag_rejected() {
+	mode=$1
+	commit=$2
+	log=$temporary/$mode-rejected.log
+
+	if [ "$mode" = checkout ]; then
+		if sh "$project_root/tools/version.sh" "$temporary/repository" >"$log" 2>&1; then
+			echo "$mode accepted a tag that does not match VERSION" >&2
+			exit 1
+		fi
+	else
+		if sh "$project_root/tools/version.sh" --commit "$temporary/repository" "$commit" \
+		    >"$log" 2>&1; then
+			echo "$mode accepted a tag that does not match VERSION" >&2
+			exit 1
+		fi
+	fi
+	if ! grep -F "tag v2.0.0 does not match package version 1.2.3" "$log" >/dev/null; then
+		echo "$mode rejection did not explain the tag mismatch" >&2
+		cat "$log" >&2
+		exit 1
+	fi
+}
+
+trap cleanup EXIT HUP INT TERM
+mkdir -p "$temporary/repository"
+git -C "$temporary/repository" init --quiet
+git -C "$temporary/repository" config user.name "exfat-resize test"
+git -C "$temporary/repository" config user.email "test@example.invalid"
+printf '%s\n' 1.2.3 >"$temporary/repository/VERSION"
+git -C "$temporary/repository" add VERSION
+git -C "$temporary/repository" commit --quiet -m "Matching version"
+matching_commit=$(git -C "$temporary/repository" rev-parse HEAD)
+git -C "$temporary/repository" tag v1.2.3
+
+expected=$(printf '1.2.3\n1.2.3')
+expect_version checkout "$matching_commit" "$expected"
+expect_version commit "$matching_commit" "$expected"
+
+printf '%s\n' mismatch >"$temporary/repository/change"
+git -C "$temporary/repository" add change
+git -C "$temporary/repository" commit --quiet -m "Mismatching tag"
+mismatching_commit=$(git -C "$temporary/repository" rev-parse HEAD)
+git -C "$temporary/repository" tag v2.0.0
+
+expect_tag_rejected checkout "$mismatching_commit"
+expect_tag_rejected commit "$mismatching_commit"
+
+echo "version: passed"

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -41,6 +41,23 @@ validate_build_version() {
 	esac
 }
 
+validate_exact_tag() {
+	if [ -n "$1" ] && [ "$1" != "v$2" ]; then
+		fail "tag $1 does not match package version $2"
+	fi
+}
+
+format_description() {
+	case $1 in
+	v*)
+		printf '%s\n' "${1#v}"
+		;;
+	*)
+		printf '%s\n' "$2-g$1"
+		;;
+	esac
+}
+
 describe_checkout() {
 	source_dir=$1
 	package_version=$2
@@ -53,21 +70,12 @@ describe_checkout() {
 		    --match "v[0-9]*" 2>/dev/null); then
 			exact_tag=$candidate
 		fi
-		if [ -n "$exact_tag" ] && [ "$exact_tag" != "v$package_version" ]; then
-			fail "tag $exact_tag does not match package version $package_version"
-		fi
+		validate_exact_tag "$exact_tag" "$package_version"
 		if ! description=$(git -C "$source_dir" describe --tags \
 		    --match "v[0-9]*" --always --dirty 2>/dev/null); then
 			fail "could not describe Git checkout"
 		fi
-		case $description in
-		v*)
-			build_version=${description#v}
-			;;
-		*)
-			build_version=$package_version-g$description
-			;;
-		esac
+		build_version=$(format_description "$description" "$package_version")
 	else
 		build_version=$package_version-unknown
 	fi
@@ -85,21 +93,12 @@ describe_commit() {
 	    --match "v[0-9]*" "$commit" 2>/dev/null); then
 		exact_tag=$candidate
 	fi
-	if [ -n "$exact_tag" ] && [ "$exact_tag" != "v$package_version" ]; then
-		fail "tag $exact_tag does not match package version $package_version"
-	fi
+	validate_exact_tag "$exact_tag" "$package_version"
 	if ! description=$(git -C "$source_dir" describe --tags \
 	    --match "v[0-9]*" --always "$commit" 2>/dev/null); then
 		fail "could not describe commit $commit"
 	fi
-	case $description in
-	v*)
-		build_version=${description#v}
-		;;
-	*)
-		build_version=$package_version-g$description
-		;;
-	esac
+	build_version=$(format_description "$description" "$package_version")
 
 	printf '%s\n' "$build_version"
 }


### PR DESCRIPTION
Remove unused cursor offset handling and geometry generality, eliminate an unreachable mapping check, and centralize sector-size validation. Simplify test-device snapshots and version description handling, with regression coverage for crash restoration and exact Git tags.