### PR TITLE
Document boot-region durability contracts

### DIFF
--- a/lib/boot_region.h
+++ b/lib/boot_region.h
@@ -32,12 +32,36 @@ enum exfat_resize_error exfat_resize_read_boot_regions(
     size_t work_buffer_size,
     struct exfat_resize_geometry *geometry);
 
+/*
+ * Updates the VolumeFlags field in main boot sector zero, then synchronizes
+ * the device. Setting the volume dirty also clears the ClearToZero flag.
+ *
+ * The device and both boot regions must already have been validated.
+ * work_buffer must hold at least one logical sector and is overwritten. The
+ * caller must select any externally reported transaction stage before calling.
+ * Success means the updated sector is durable. On failure, the sector may
+ * already have been written without a successful synchronization.
+ */
 enum exfat_resize_error exfat_resize_set_volume_dirty(
     const struct exfat_resize_block_device *device,
     void *work_buffer,
     size_t work_buffer_size,
     int dirty);
 
+/*
+ * Updates the target geometry and PercentInUse in the backup boot sector,
+ * rebuilds its checksum sector, and synchronizes the device. It then performs
+ * the same updates to the main boot and checksum sectors and synchronizes
+ * again. The remaining sectors in both boot regions are preserved.
+ *
+ * The device and existing boot regions must already have been validated.
+ * geometry must describe a valid planned target; used_cluster_count must not
+ * exceed its nonzero cluster count. work_buffer must hold at least one logical
+ * sector and is overwritten. The caller must select any externally reported
+ * transaction stage before calling. Success means both updated regions are
+ * durable. On failure, earlier writes may remain, and the most recent writes
+ * may not have been synchronized.
+ */
 enum exfat_resize_error exfat_resize_write_boot_regions(
     const struct exfat_resize_block_device *device,
     const struct exfat_resize_geometry *geometry,


### PR DESCRIPTION
Describe mutation ordering, synchronization guarantees, preconditions, and partial-failure behavior for the private boot-region write helpers.