### PR TITLE
Improve preflight FAT access performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ enum exfat_resize_stage stage;
 error = exfat_resize(&device, target_size, &options, &stage);
 ```
 
-Before writing, the library rebuilds and validates an in-memory allocation
-model covering the target cluster heap. See the transaction document's
-[memory requirements](docs/TRANSACTION.md#memory-requirements) for
-allocator-backed working-memory sizes, lifetimes, and backing options.
+Before writing, the library snapshots the used source FAT and rebuilds a
+validated in-memory allocation model covering the target cluster heap. See the
+transaction document's [memory requirements](docs/TRANSACTION.md#memory-requirements)
+for allocator-backed working-memory sizes, lifetimes, and backing options.
 
 When an error is returned, `stage` describes the recovery boundary reached:
 

--- a/docs/TRANSACTION.md
+++ b/docs/TRANSACTION.md
@@ -62,19 +62,23 @@ The library requests a 1 MiB I/O work buffer through the caller's allocator.
 It uses that buffer for boot-region I/O, cluster relocation, batched FAT and
 bitmap output, and buffering directory entry sets.
 
-It separately requests a cache block containing seven filesystem sectors.
-Dedicated caches retain source directory data, source directory FAT entries,
-source bitmap data, source bitmap FAT entries, source allocation-model FAT
-entries, target directory data, and target directory FAT entries. Directory
-entry sets are checksummed and rewritten one 32-byte entry at a time.
+During preflight, it requests a snapshot of the used portion of the source FAT,
+rounded up to a filesystem sector. The snapshot is filled by one block-device
+read, provides all source FAT lookups, and is released before the first write.
+Its size is approximately four bytes per source cluster.
+
+It separately requests a cache block containing three filesystem sectors.
+Dedicated caches retain source directory data, source bitmap data, and target
+directory data. Directory entry sets are checksummed and rewritten one 32-byte
+entry at a time.
 
 In addition, `exfat_resize()` requests a writable allocation model containing
 one 32-bit value per target cluster. The model distinguishes free clusters,
 bad clusters, `NoFatChain` allocations, and target FAT links. It is completely
 built and checked against the source bitmap before the dirty flag is set, then
-used to generate both the target FAT and target bitmap. The caller controls
-how this memory is backed through the allocator callbacks; anonymous memory
-and a memory-mapped temporary file are both possible.
+used to generate the target FAT and bitmap and to traverse target directories.
+The caller controls how allocator-backed working memory is backed; anonymous
+memory and a memory-mapped temporary file are both possible.
 
 Directory traversal uses an additional allocator-backed worklist. It may grow
 during preflight, but its final capacity is retained and reused during the

--- a/lib/resize.c
+++ b/lib/resize.c
@@ -76,21 +76,15 @@ struct sector_cache {
 enum sector_cache_index {
 	/* Source directory payload sectors read during preflight validation. */
 	SECTOR_CACHE_SOURCE_DIRECTORY_DATA,
-	/* Source FAT sectors used to advance preflight directory streams. */
-	SECTOR_CACHE_SOURCE_DIRECTORY_FAT,
 	/* Source allocation-bitmap payload sectors read during reconciliation. */
 	SECTOR_CACHE_SOURCE_BITMAP_DATA,
-	/* Source FAT sectors used to advance the allocation-bitmap stream. */
-	SECTOR_CACHE_SOURCE_BITMAP_FAT,
-	/* Source FAT sectors used to claim and reconcile allocated clusters. */
-	SECTOR_CACHE_SOURCE_ALLOCATION_FAT,
 	/* Target directory payload sectors read and written during rewrite. */
 	SECTOR_CACHE_TARGET_DIRECTORY_DATA,
-	/* Target FAT sectors used to advance directory streams during rewrite. */
-	SECTOR_CACHE_TARGET_DIRECTORY_FAT,
 	/* Number of independently backed sector caches. Must be last! */
 	SECTOR_CACHE_COUNT
 };
+
+enum stream_chain_source { STREAM_CHAIN_SOURCE_FAT, STREAM_CHAIN_TARGET_MODEL };
 
 struct allocation_stream {
 	uint32_t first_cluster;
@@ -103,7 +97,7 @@ struct stream_cursor {
 	struct allocation_stream stream;
 	const struct exfat_resize_geometry *geometry;
 	enum sector_cache_index data_cache;
-	enum sector_cache_index fat_cache;
+	enum stream_chain_source chain_source;
 	uint32_t current_cluster;
 	uint32_t traversed_clusters;
 	uint64_t cluster_offset;
@@ -149,6 +143,8 @@ struct resize_context {
 	uint32_t displaced_cluster_count;
 	uint32_t used_cluster_count;
 	uint32_t fat_entry_zero;
+	unsigned char *source_fat;
+	size_t source_fat_size;
 	/* Indexed by target cluster minus 2; one entry for every target cluster. */
 	uint32_t *allocation_model;
 	size_t allocation_model_size;
@@ -230,44 +226,52 @@ static int cluster_is_valid(const struct exfat_resize_geometry *geometry, uint32
 	return cluster >= 2 && cluster <= geometry->cluster_count + UINT32_C(1);
 }
 
-static enum exfat_resize_error fat_entry_location(const struct resize_context *context,
-    const struct exfat_resize_geometry *geometry,
-    uint32_t cluster,
-    uint64_t *sector,
-    size_t *offset)
+static enum exfat_resize_error load_source_fat(struct resize_context *context)
 {
-	uint64_t byte_offset;
-	uint64_t fat_sector;
+	enum exfat_resize_error error;
+	uint64_t byte_count = ((uint64_t)context->source.cluster_count + 2) * 4;
+	uint64_t sector_count;
+	uint64_t allocation_size;
 
-	if (cluster > geometry->cluster_count + UINT32_C(1))
-		return EXFAT_RESIZE_OUT_OF_BOUNDS;
-	byte_offset = (uint64_t)cluster * 4;
-	fat_sector = byte_offset / context->sector_size;
-	if (fat_sector >= geometry->fat_length)
-		return EXFAT_RESIZE_OUT_OF_BOUNDS;
-	*sector = (uint64_t)geometry->fat_offset + fat_sector;
-	*offset = (size_t)(byte_offset % context->sector_size);
-	return EXFAT_RESIZE_SUCCESS;
+	error = exfat_resize_checked_ceil_divide_u64(byte_count, context->sector_size, &sector_count);
+	if (error != EXFAT_RESIZE_SUCCESS)
+		return error;
+	if (sector_count > context->source.fat_length)
+		return EXFAT_RESIZE_INVALID_FILESYSTEM;
+	error = exfat_resize_checked_multiply_u64(sector_count, context->sector_size, &allocation_size);
+	if (error != EXFAT_RESIZE_SUCCESS)
+		return error;
+	context->source_fat_size = (size_t)allocation_size;
+	if (context->source_fat_size != allocation_size)
+		return EXFAT_RESIZE_ARITHMETIC_OVERFLOW;
+	context->source_fat =
+	    context->allocator.allocate(context->allocator.context, context->source_fat_size);
+	if (context->source_fat == NULL)
+		return EXFAT_RESIZE_OUT_OF_MEMORY;
+
+	return exfat_resize_block_device_read(context->device, context->source.fat_offset,
+	    (uint32_t)sector_count, context->source_fat, context->source_fat_size);
 }
 
-static enum exfat_resize_error fat_get(struct resize_context *context,
-    const struct exfat_resize_geometry *geometry,
-    uint32_t cluster,
-    enum sector_cache_index cache_index,
-    uint32_t *value)
+static enum exfat_resize_error source_fat_get(
+    const struct resize_context *context, uint32_t cluster, uint32_t *value)
 {
-	struct sector_cache *cache = &context->caches[cache_index];
-	enum exfat_resize_error error;
-	uint64_t sector;
 	size_t offset;
 
-	error = fat_entry_location(context, geometry, cluster, &sector, &offset);
-	if (error != EXFAT_RESIZE_SUCCESS)
-		return error;
-	error = load_cache(context, cache_index, sector);
-	if (error != EXFAT_RESIZE_SUCCESS)
-		return error;
-	return exfat_resize_load_le32(cache->data, context->sector_size, offset, value);
+	if (cluster > context->source.cluster_count + UINT32_C(1))
+		return EXFAT_RESIZE_OUT_OF_BOUNDS;
+	offset = (size_t)cluster * 4;
+	return exfat_resize_load_le32(context->source_fat, context->source_fat_size, offset, value);
+}
+
+static void release_source_fat(struct resize_context *context)
+{
+	if (context->source_fat == NULL)
+		return;
+	context->allocator.deallocate(
+	    context->allocator.context, context->source_fat, context->source_fat_size);
+	context->source_fat = NULL;
+	context->source_fat_size = 0;
 }
 
 static enum exfat_resize_error validate_reserved_fat_entries(struct resize_context *context)
@@ -275,11 +279,10 @@ static enum exfat_resize_error validate_reserved_fat_entries(struct resize_conte
 	enum exfat_resize_error error;
 	uint32_t entry_one;
 
-	error = fat_get(
-	    context, &context->source, 0, SECTOR_CACHE_SOURCE_ALLOCATION_FAT, &context->fat_entry_zero);
+	error = source_fat_get(context, 0, &context->fat_entry_zero);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
-	error = fat_get(context, &context->source, 1, SECTOR_CACHE_SOURCE_ALLOCATION_FAT, &entry_one);
+	error = source_fat_get(context, 1, &entry_one);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
 
@@ -390,8 +393,7 @@ static enum exfat_resize_error claim_allocation_stream(
 			return error;
 		if (*model_entry != 0)
 			return EXFAT_RESIZE_INVALID_FILESYSTEM;
-		error =
-		    fat_get(context, &context->source, cluster, SECTOR_CACHE_SOURCE_ALLOCATION_FAT, &next);
+		error = source_fat_get(context, cluster, &next);
 		if (error != EXFAT_RESIZE_SUCCESS)
 			return error;
 		if (index + 1 == cluster_count) {
@@ -432,8 +434,7 @@ static enum exfat_resize_error claim_root_directory(
 			return error;
 		if (*model_entry != 0)
 			return EXFAT_RESIZE_INVALID_FILESYSTEM;
-		error =
-		    fat_get(context, &context->source, cluster, SECTOR_CACHE_SOURCE_ALLOCATION_FAT, &next);
+		error = source_fat_get(context, cluster, &next);
 		if (error != EXFAT_RESIZE_SUCCESS)
 			return error;
 		if (fat_value_is_end_of_chain(next)) {
@@ -459,11 +460,18 @@ static enum exfat_resize_error next_stream_cluster(
 
 	if (cursor->stream.no_fat_chain) {
 		next = cursor->current_cluster + 1;
-	} else {
-		error =
-		    fat_get(context, cursor->geometry, cursor->current_cluster, cursor->fat_cache, &next);
+	} else if (cursor->chain_source == STREAM_CHAIN_SOURCE_FAT) {
+		error = source_fat_get(context, cursor->current_cluster, &next);
 		if (error != EXFAT_RESIZE_SUCCESS)
 			return error;
+	} else {
+		if (!cluster_is_valid(&context->target, cursor->current_cluster))
+			return EXFAT_RESIZE_INTERNAL_ERROR;
+		next = context->allocation_model[cursor->current_cluster - 2];
+		if (next == 0 || next == EXFAT_MODEL_NO_FAT_CHAIN || next == EXFAT_FAT_BAD_CLUSTER)
+			return EXFAT_RESIZE_INTERNAL_ERROR;
+	}
+	if (!cursor->stream.no_fat_chain) {
 		if (fat_value_is_end_of_chain(next)) {
 			if (!cursor->stream.root_directory && cursor->remaining_bytes != 0)
 				return EXFAT_RESIZE_INVALID_FILESYSTEM;
@@ -485,7 +493,7 @@ static enum exfat_resize_error initialize_stream_cursor(
     const struct exfat_resize_geometry *geometry,
     const struct allocation_stream *stream,
     enum sector_cache_index data_cache,
-    enum sector_cache_index fat_cache,
+    enum stream_chain_source chain_source,
     struct stream_cursor *cursor)
 {
 	if (!cluster_is_valid(geometry, stream->first_cluster))
@@ -495,7 +503,7 @@ static enum exfat_resize_error initialize_stream_cursor(
 	cursor->stream = *stream;
 	cursor->geometry = geometry;
 	cursor->data_cache = data_cache;
-	cursor->fat_cache = fat_cache;
+	cursor->chain_source = chain_source;
 	cursor->current_cluster = stream->first_cluster;
 	cursor->remaining_bytes = stream->root_directory ? UINT64_MAX : stream->data_length;
 	if (cursor->remaining_bytes == 0)
@@ -1053,10 +1061,10 @@ static enum exfat_resize_error scan_one_directory(struct resize_context *context
 
 	if (mode == DIRECTORY_SCAN_REWRITE) {
 		error = initialize_stream_cursor(&context->target, directory,
-		    SECTOR_CACHE_TARGET_DIRECTORY_DATA, SECTOR_CACHE_TARGET_DIRECTORY_FAT, &cursor);
+		    SECTOR_CACHE_TARGET_DIRECTORY_DATA, STREAM_CHAIN_TARGET_MODEL, &cursor);
 	} else {
 		error = initialize_stream_cursor(&context->source, directory,
-		    SECTOR_CACHE_SOURCE_DIRECTORY_DATA, SECTOR_CACHE_SOURCE_DIRECTORY_FAT, &cursor);
+		    SECTOR_CACHE_SOURCE_DIRECTORY_DATA, STREAM_CHAIN_SOURCE_FAT, &cursor);
 	}
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
@@ -1129,7 +1137,7 @@ static enum exfat_resize_error initialize_bitmap_reader(
 {
 	memset(reader, 0, sizeof(*reader));
 	return initialize_stream_cursor(&context->source, &context->old_bitmap,
-	    SECTOR_CACHE_SOURCE_BITMAP_DATA, SECTOR_CACHE_SOURCE_BITMAP_FAT, &reader->cursor);
+	    SECTOR_CACHE_SOURCE_BITMAP_DATA, STREAM_CHAIN_SOURCE_FAT, &reader->cursor);
 }
 
 static enum exfat_resize_error read_old_bitmap_bit(
@@ -1183,8 +1191,7 @@ static enum exfat_resize_error validate_allocation_model(struct resize_context *
 			continue;
 		}
 
-		error = fat_get(context, &context->source, source_cluster,
-		    SECTOR_CACHE_SOURCE_ALLOCATION_FAT, &fat_value);
+		error = source_fat_get(context, source_cluster, &fat_value);
 		if (error != EXFAT_RESIZE_SUCCESS)
 			return error;
 		if (fat_value == EXFAT_FAT_BAD_CLUSTER) {
@@ -1504,19 +1511,11 @@ static enum exfat_resize_error prepare_context(struct resize_context *context,
 	    context->device, context->io_buffer, EXFAT_IO_BUFFER_SIZE, &context->source);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
-	if (context->sector_size > SIZE_MAX / (size_t)SECTOR_CACHE_COUNT)
-		return EXFAT_RESIZE_ARITHMETIC_OVERFLOW;
-	context->cache_buffer_size = (size_t)SECTOR_CACHE_COUNT * context->sector_size;
-	context->cache_buffer =
-	    context->allocator.allocate(context->allocator.context, context->cache_buffer_size);
-	if (context->cache_buffer == NULL)
-		return EXFAT_RESIZE_OUT_OF_MEMORY;
-	for (cache_index = 0; cache_index < SECTOR_CACHE_COUNT; ++cache_index) {
-		context->caches[cache_index].data =
-		    context->cache_buffer + cache_index * context->sector_size;
-	}
 	context->io_sector_capacity = EXFAT_IO_BUFFER_SIZE / context->sector_size;
 
+	error = load_source_fat(context);
+	if (error != EXFAT_RESIZE_SUCCESS)
+		return error;
 	error = validate_reserved_fat_entries(context);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
@@ -1558,6 +1557,18 @@ static enum exfat_resize_error prepare_context(struct resize_context *context,
 	        (uint64_t)context->target.cluster_count + 2)
 		return EXFAT_RESIZE_INTERNAL_ERROR;
 
+	if (context->sector_size > SIZE_MAX / (size_t)SECTOR_CACHE_COUNT)
+		return EXFAT_RESIZE_ARITHMETIC_OVERFLOW;
+	context->cache_buffer_size = (size_t)SECTOR_CACHE_COUNT * context->sector_size;
+	context->cache_buffer =
+	    context->allocator.allocate(context->allocator.context, context->cache_buffer_size);
+	if (context->cache_buffer == NULL)
+		return EXFAT_RESIZE_OUT_OF_MEMORY;
+	for (cache_index = 0; cache_index < SECTOR_CACHE_COUNT; ++cache_index) {
+		context->caches[cache_index].data =
+		    context->cache_buffer + cache_index * context->sector_size;
+	}
+
 	model_size = (uint64_t)context->target.cluster_count * sizeof(*context->allocation_model);
 	context->allocation_model_size = (size_t)model_size;
 	if (context->allocation_model_size != model_size)
@@ -1589,6 +1600,7 @@ static enum exfat_resize_error prepare_context(struct resize_context *context,
 	error = add_new_bitmap_to_model(context);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
+	release_source_fat(context);
 	return EXFAT_RESIZE_SUCCESS;
 }
 
@@ -1598,9 +1610,9 @@ static enum exfat_resize_error run_transaction(struct resize_context *context)
 	enum exfat_resize_error error;
 
 	/*
-	 * Direct transaction I/O may make the source caches stale, but they are
-	 * reserved for preflight and are never consulted below. Target caches
-	 * have not yet been populated.
+	 * Direct transaction I/O may make the source data caches stale, but they
+	 * are reserved for preflight and are never consulted below. The target
+	 * directory cache has not yet been populated.
 	 */
 	context->stage = EXFAT_RESIZE_STAGE_PREPARING;
 	error =
@@ -1655,6 +1667,7 @@ static enum exfat_resize_error run_transaction(struct resize_context *context)
 
 static void release_context(struct resize_context *context)
 {
+	release_source_fat(context);
 	if (context->directories.items != NULL) {
 		context->allocator.deallocate(context->allocator.context, context->directories.items,
 		    context->directories.capacity * sizeof(*context->directories.items));

--- a/tests/library/integration/resize_tests.c
+++ b/tests/library/integration/resize_tests.c
@@ -19,6 +19,8 @@ enum {
 	WORK_BUFFER_SIZE = 1024 * 1024,
 	PERFORMANCE_DIRECTORY_FIRST_CLUSTER = 1024,
 	PERFORMANCE_DIRECTORY_CLUSTER_COUNT = 4096,
+	PERFORMANCE_FILE_CLUSTER_COUNT = 8192,
+	PERFORMANCE_FILE_PRIMARY_OFFSET = 352,
 	VOLUME_FLAGS_OFFSET = 106,
 	ENTRY_BITMAP = 0x81,
 	ENTRY_FILE = 0x85,
@@ -226,22 +228,29 @@ static size_t sector_operation_count(
 	return count;
 }
 
-static size_t preflight_read_count(
-    const struct exfat_fixture *fixture, uint64_t first_sector, uint64_t sector_count)
+static void check_source_fat_snapshot_read(const struct exfat_fixture *fixture)
 {
-	size_t count = 0;
+	uint64_t used_bytes = ((uint64_t)fixture->geometry.cluster_count + 2) * 4;
+	uint64_t used_sectors =
+	    (used_bytes + fixture->memory.device.sector_size - 1) / fixture->memory.device.sector_size;
+	size_t operation_count = 0;
 	size_t index;
 
 	for (index = 0; index < fixture->memory.operation_count; ++index) {
 		const struct memory_operation *operation = &fixture->memory.operations[index];
+		uint64_t operation_end = operation->first_sector + operation->sector_count;
 
 		if (operation->kind == MEMORY_OPERATION_WRITE)
 			break;
-		if (operation->kind == MEMORY_OPERATION_READ && operation->first_sector >= first_sector &&
-		    operation->first_sector - first_sector < sector_count)
-			++count;
+		if (operation->kind != MEMORY_OPERATION_READ ||
+		    operation->first_sector >= fixture->geometry.fat_offset + used_sectors ||
+		    operation_end <= fixture->geometry.fat_offset)
+			continue;
+		CHECK(operation->first_sector == fixture->geometry.fat_offset);
+		CHECK(operation->sector_count == used_sectors);
+		++operation_count;
 	}
-	return count;
+	CHECK(operation_count == 1);
 }
 
 static size_t rewrite_fat_read_count(const struct exfat_fixture *fixture,
@@ -384,56 +393,185 @@ static int configure_crossing_file_entry_set(
 	return 0;
 }
 
-static int set_bitmap_buffer_cluster(unsigned char *bitmap, size_t bitmap_size, uint32_t cluster)
+static int set_bitmap_buffer_cluster(
+    unsigned char *bitmap, size_t bitmap_size, uint32_t cluster, int allocated)
 {
 	uint32_t bit;
+	unsigned char mask;
 
 	if (cluster < 2)
 		return -1;
 	bit = cluster - 2;
 	if (bit / 8 >= bitmap_size)
 		return -1;
-	bitmap[bit / 8] |= (unsigned char)(1u << (bit % 8));
+	mask = (unsigned char)(1u << (bit % 8));
+	if (allocated)
+		bitmap[bit / 8] |= mask;
+	else
+		bitmap[bit / 8] &= (unsigned char)~mask;
 	return 0;
 }
 
-static int configure_fat_chained_root_directory(struct exfat_fixture *fixture)
+static int performance_cluster_is_reserved(uint32_t cluster)
+{
+	return cluster == 2 || cluster == 3 || cluster == 4 || cluster == 5 || cluster == 6 ||
+	    cluster == 7 || cluster == 8 || cluster == 10 || cluster == 11 || cluster == 12 ||
+	    cluster == 20 || (cluster >= 100 && cluster < 400);
+}
+
+static int make_performance_chain(
+    const struct exfat_fixture *fixture, uint32_t *clusters, uint32_t count, int fragmented)
+{
+	uint32_t made = 0;
+	uint32_t round;
+	uint32_t fat_sector;
+	uint32_t cluster;
+
+	if (!fragmented) {
+		for (cluster = PERFORMANCE_DIRECTORY_FIRST_CLUSTER;
+		    cluster <= fixture->geometry.cluster_count + 1 && made < count; ++cluster) {
+			if (!performance_cluster_is_reserved(cluster))
+				clusters[made++] = cluster;
+		}
+		return made == count ? 0 : -1;
+	}
+
+	for (round = 0; round < SECTOR_SIZE / 4 && made < count; ++round) {
+		for (fat_sector = 1; fat_sector < fixture->geometry.fat_length && made < count;
+		    ++fat_sector) {
+			cluster = fat_sector * (SECTOR_SIZE / 4) + round;
+			if (cluster <= fixture->geometry.cluster_count + 1 &&
+			    !performance_cluster_is_reserved(cluster))
+				clusters[made++] = cluster;
+		}
+	}
+	return made == count ? 0 : -1;
+}
+
+static int configure_fat_chained_file(
+    struct exfat_fixture *fixture, uint32_t cluster_count, int fragmented)
+{
+	unsigned char root[SECTOR_SIZE];
+	unsigned char *bitmap = NULL;
+	unsigned char *fat = NULL;
+	uint32_t *clusters = NULL;
+	unsigned char *entry_set = root + PERFORMANCE_FILE_PRIMARY_OFFSET;
+	unsigned char *stream = entry_set + 32;
+	size_t bitmap_size = (size_t)fixture->bitmap_cluster_count * SECTOR_SIZE;
+	size_t fat_size = (size_t)fixture->geometry.fat_length * SECTOR_SIZE;
+	uint32_t index;
+	int result = -1;
+
+	clusters = malloc((size_t)cluster_count * sizeof(*clusters));
+	fat = malloc(fat_size);
+	bitmap = malloc(bitmap_size);
+	if (clusters == NULL || fat == NULL || bitmap == NULL)
+		goto done;
+	if (make_performance_chain(fixture, clusters, cluster_count, fragmented) != 0)
+		goto done;
+	if (fixture->memory.device.read(fixture->memory.device.context, fixture->geometry.fat_offset,
+	        fixture->geometry.fat_length, fat) != 0)
+		goto done;
+	for (index = 0; index < fixture->bitmap_cluster_count; ++index) {
+		if (fixture->memory.device.read(fixture->memory.device.context,
+		        exfat_fixture_cluster_sector(&fixture->geometry, fixture->bitmap_clusters[index]),
+		        1, bitmap + (size_t)index * SECTOR_SIZE) != 0)
+			goto done;
+	}
+	if (exfat_fixture_read_sector(fixture,
+	        exfat_fixture_cluster_sector(
+	            &fixture->geometry, fixture->geometry.root_directory_cluster),
+	        root, sizeof(root)) != 0 ||
+	    entry_set[0] != ENTRY_FILE || stream[0] != ENTRY_STREAM)
+		goto done;
+
+	for (index = 0; index < 3; ++index) {
+		uint32_t old_cluster = fixture->fragmented_clusters[index];
+
+		if (exfat_resize_store_le32(fat, fat_size, (size_t)old_cluster * 4, 0) !=
+		        EXFAT_RESIZE_SUCCESS ||
+		    set_bitmap_buffer_cluster(bitmap, bitmap_size, old_cluster, 0) != 0)
+			goto done;
+	}
+	for (index = 0; index < cluster_count; ++index) {
+		uint32_t next = index + 1 == cluster_count ? UINT32_C(0xffffffff) : clusters[index + 1];
+
+		if (exfat_resize_store_le32(fat, fat_size, (size_t)clusters[index] * 4, next) !=
+		        EXFAT_RESIZE_SUCCESS ||
+		    set_bitmap_buffer_cluster(bitmap, bitmap_size, clusters[index], 1) != 0)
+			goto done;
+	}
+	stream[1] = ALLOCATION_POSSIBLE;
+	if (exfat_resize_store_le64(stream, 32, 8, (uint64_t)cluster_count * SECTOR_SIZE) !=
+	        EXFAT_RESIZE_SUCCESS ||
+	    exfat_resize_store_le32(stream, 32, 20, clusters[0]) != EXFAT_RESIZE_SUCCESS ||
+	    exfat_resize_store_le64(stream, 32, 24, (uint64_t)cluster_count * SECTOR_SIZE) !=
+	        EXFAT_RESIZE_SUCCESS ||
+	    exfat_resize_store_le16(entry_set, 32, 2, entry_set_checksum(entry_set)) !=
+	        EXFAT_RESIZE_SUCCESS)
+		goto done;
+
+	if (fixture->memory.device.write(fixture->memory.device.context, fixture->geometry.fat_offset,
+	        fixture->geometry.fat_length, fat) != 0 ||
+	    fixture->memory.device.write(fixture->memory.device.context,
+	        exfat_fixture_cluster_sector(
+	            &fixture->geometry, fixture->geometry.root_directory_cluster),
+	        1, root) != 0)
+		goto done;
+	for (index = 0; index < fixture->bitmap_cluster_count; ++index) {
+		if (fixture->memory.device.write(fixture->memory.device.context,
+		        exfat_fixture_cluster_sector(&fixture->geometry, fixture->bitmap_clusters[index]),
+		        1, bitmap + (size_t)index * SECTOR_SIZE) != 0)
+			goto done;
+	}
+	result = 0;
+
+done:
+	free(clusters);
+	free(bitmap);
+	free(fat);
+	if (result == 0)
+		memory_block_device_clear_operations(&fixture->memory);
+	return result;
+}
+
+static int configure_fat_chained_root_directory(struct exfat_fixture *fixture, int fragmented)
 {
 	const uint32_t continuation_count = PERFORMANCE_DIRECTORY_CLUSTER_COUNT - 1;
 	unsigned char root[SECTOR_SIZE];
 	unsigned char *bitmap = NULL;
 	unsigned char *directory_data = NULL;
 	unsigned char *fat = NULL;
+	uint32_t *clusters = NULL;
 	size_t bitmap_size;
 	size_t directory_size;
 	size_t fat_size;
 	size_t offset;
-	uint32_t cluster;
 	uint32_t index;
 	int result = -1;
 
-	if (fixture->geometry.sectors_per_cluster != 1 ||
-	    PERFORMANCE_DIRECTORY_FIRST_CLUSTER + continuation_count >
-	        fixture->geometry.cluster_count + 2)
+	if (fixture->geometry.sectors_per_cluster != 1)
 		return -1;
 	fat_size = (size_t)fixture->geometry.fat_length * SECTOR_SIZE;
 	bitmap_size = (size_t)fixture->bitmap_cluster_count * SECTOR_SIZE;
 	directory_size = (size_t)continuation_count * SECTOR_SIZE;
+	clusters = malloc((size_t)continuation_count * sizeof(*clusters));
 	fat = malloc(fat_size);
 	bitmap = malloc(bitmap_size);
 	directory_data = calloc(1, directory_size);
-	if (fat == NULL || bitmap == NULL || directory_data == NULL)
+	if (clusters == NULL || fat == NULL || bitmap == NULL || directory_data == NULL)
+		goto done;
+	if (make_performance_chain(fixture, clusters, continuation_count, fragmented) != 0)
 		goto done;
 
 	if (fixture->memory.device.read(fixture->memory.device.context, fixture->geometry.fat_offset,
 	        fixture->geometry.fat_length, fat) != 0)
 		goto done;
 	for (index = 0; index < PERFORMANCE_DIRECTORY_CLUSTER_COUNT; ++index) {
-		uint32_t current = index == 0 ? fixture->geometry.root_directory_cluster
-		                              : PERFORMANCE_DIRECTORY_FIRST_CLUSTER + index - 1;
-		uint32_t next = index + 1 == PERFORMANCE_DIRECTORY_CLUSTER_COUNT
-		    ? UINT32_C(0xffffffff)
-		    : PERFORMANCE_DIRECTORY_FIRST_CLUSTER + index;
+		uint32_t current =
+		    index == 0 ? fixture->geometry.root_directory_cluster : clusters[index - 1];
+		uint32_t next = index + 1 == PERFORMANCE_DIRECTORY_CLUSTER_COUNT ? UINT32_C(0xffffffff)
+		                                                                 : clusters[index];
 
 		if (exfat_resize_store_le32(fat, fat_size, (size_t)current * 4, next) !=
 		    EXFAT_RESIZE_SUCCESS)
@@ -446,9 +584,8 @@ static int configure_fat_chained_root_directory(struct exfat_fixture *fixture)
 		        1, bitmap + (size_t)index * SECTOR_SIZE) != 0)
 			goto done;
 	}
-	for (cluster = PERFORMANCE_DIRECTORY_FIRST_CLUSTER;
-	    cluster < PERFORMANCE_DIRECTORY_FIRST_CLUSTER + continuation_count; ++cluster) {
-		if (set_bitmap_buffer_cluster(bitmap, bitmap_size, cluster) != 0)
+	for (index = 0; index < continuation_count; ++index) {
+		if (set_bitmap_buffer_cluster(bitmap, bitmap_size, clusters[index], 1) != 0)
 			goto done;
 	}
 
@@ -473,11 +610,14 @@ static int configure_fat_chained_root_directory(struct exfat_fixture *fixture)
 	    fixture->memory.device.write(fixture->memory.device.context,
 	        exfat_fixture_cluster_sector(
 	            &fixture->geometry, fixture->geometry.root_directory_cluster),
-	        1, root) != 0 ||
-	    fixture->memory.device.write(fixture->memory.device.context,
-	        exfat_fixture_cluster_sector(&fixture->geometry, PERFORMANCE_DIRECTORY_FIRST_CLUSTER),
-	        continuation_count, directory_data) != 0)
+	        1, root) != 0)
 		goto done;
+	for (index = 0; index < continuation_count; ++index) {
+		if (fixture->memory.device.write(fixture->memory.device.context,
+		        exfat_fixture_cluster_sector(&fixture->geometry, clusters[index]), 1,
+		        directory_data + (size_t)index * SECTOR_SIZE) != 0)
+			goto done;
+	}
 	for (index = 0; index < fixture->bitmap_cluster_count; ++index) {
 		if (fixture->memory.device.write(fixture->memory.device.context,
 		        exfat_fixture_cluster_sector(&fixture->geometry, fixture->bitmap_clusters[index]),
@@ -487,6 +627,7 @@ static int configure_fat_chained_root_directory(struct exfat_fixture *fixture)
 	result = 0;
 
 done:
+	free(clusters);
 	free(directory_data);
 	free(bitmap);
 	free(fat);
@@ -581,8 +722,8 @@ static void test_resize(void)
 	error = exfat_resize(&fixture.memory.device,
 	    exfat_fixture_target_size(TARGET_SECTOR_COUNT) + SECTOR_SIZE - 1, &options, NULL);
 	CHECK(error == EXFAT_RESIZE_SUCCESS);
-	CHECK(allocator.tracker.allocation_attempts == 4);
-	CHECK(allocator.tracker.deallocation_calls == 4);
+	CHECK(allocator.tracker.allocation_attempts == 5);
+	CHECK(allocator.tracker.deallocation_calls == 5);
 	CHECK(allocator.tracker.largest_requested_size == WORK_BUFFER_SIZE);
 	CHECK(test_allocator_is_clean(&allocator.tracker));
 	if (error != EXFAT_RESIZE_SUCCESS) {
@@ -803,7 +944,7 @@ static void test_preflight_is_read_only(void)
 	exfat_fixture_destroy(&fixture);
 }
 
-static void test_invalid_entry_checksum_does_not_direct_fat_reads(void)
+static void test_invalid_entry_checksum_does_not_follow_fat(void)
 {
 	const uint32_t untrusted_cluster = 200;
 	struct exfat_resize_options options = resize_options();
@@ -814,13 +955,10 @@ static void test_invalid_entry_checksum_does_not_direct_fat_reads(void)
 	enum exfat_resize_error error;
 	enum exfat_resize_stage stage = EXFAT_RESIZE_STAGE_COMPLETED;
 	uint64_t root_sector;
-	uint64_t untrusted_fat_sector;
 	uint16_t stored_checksum = 0;
 
 	CHECK(exfat_fixture_initialize(&fixture, TARGET_SECTOR_COUNT) == 0);
 	root_sector = exfat_fixture_cluster_sector(&fixture.geometry, 2);
-	untrusted_fat_sector =
-	    fixture.geometry.fat_offset + (uint64_t)untrusted_cluster * 4 / SECTOR_SIZE;
 	CHECK(exfat_fixture_read_sector(&fixture, root_sector, root, sizeof(root)) == 0);
 	stream[1] = ALLOCATION_POSSIBLE;
 	CHECK(exfat_resize_store_le32(stream, 32, 20, untrusted_cluster) == EXFAT_RESIZE_SUCCESS);
@@ -835,7 +973,7 @@ static void test_invalid_entry_checksum_does_not_direct_fat_reads(void)
 	CHECK(error == EXFAT_RESIZE_INVALID_FILESYSTEM);
 	CHECK(stage == EXFAT_RESIZE_STAGE_PREFLIGHT);
 	check_operations_are_read_only(&fixture);
-	check_sector_is_not_read(&fixture, untrusted_fat_sector);
+	check_source_fat_snapshot_read(&fixture);
 	exfat_fixture_destroy(&fixture);
 }
 
@@ -1260,7 +1398,6 @@ static void test_oversized_child_directory_is_rejected(void)
 	unsigned char root[SECTOR_SIZE];
 	unsigned char child_entry_set[32 * 3];
 	enum exfat_resize_error error;
-	uint64_t child_fat_sector;
 	uint64_t root_sector;
 	uint64_t target_sector_count;
 	uint16_t checksum;
@@ -1296,14 +1433,13 @@ static void test_oversized_child_directory_is_rejected(void)
 	CHECK(exfat_fixture_write_boot_regions(&fixture) == 0);
 	root_sector = exfat_fixture_cluster_sector(&fixture.geometry, 2);
 	CHECK(fixture.memory.device.write(fixture.memory.device.context, root_sector, 1, root) == 0);
-	child_fat_sector = fixture.geometry.fat_offset + (uint64_t)200 * 4 / SECTOR_SIZE;
 	memory_block_device_clear_operations(&fixture.memory);
 
 	options = resize_options();
 	error = exfat_fixture_resize(&fixture.memory.device, target_sector_count, &options, NULL);
 	CHECK(error == EXFAT_RESIZE_INVALID_FILESYSTEM);
 	check_operations_are_read_only(&fixture);
-	check_sector_is_not_read(&fixture, child_fat_sector);
+	check_source_fat_snapshot_read(&fixture);
 	exfat_fixture_destroy(&fixture);
 }
 
@@ -1394,8 +1530,8 @@ static void test_allocation_model_validates_bitmap(void)
 	options = tracked_resize_options(&allocator);
 	error = exfat_fixture_resize(&fixture.memory.device, TARGET_SECTOR_COUNT, &options, NULL);
 	CHECK(error == EXFAT_RESIZE_INVALID_FILESYSTEM);
-	CHECK(allocator.tracker.allocation_attempts == 4);
-	CHECK(allocator.tracker.deallocation_calls == 4);
+	CHECK(allocator.tracker.allocation_attempts == 5);
+	CHECK(allocator.tracker.deallocation_calls == 5);
 	CHECK(allocator.tracker.largest_requested_size == WORK_BUFFER_SIZE);
 	CHECK(test_allocator_is_clean(&allocator.tracker));
 	check_operations_are_read_only(&fixture);
@@ -1481,8 +1617,8 @@ static void test_displaced_bad_cluster_is_rejected(void)
 		error = exfat_fixture_resize(
 		    &fixture.memory.device, cases[index].target_sector_count, &options, NULL);
 		CHECK(error == EXFAT_RESIZE_BAD_CLUSTER_CONFLICT);
-		CHECK(allocator.tracker.allocation_attempts == 4);
-		CHECK(allocator.tracker.deallocation_calls == 4);
+		CHECK(allocator.tracker.allocation_attempts == 5);
+		CHECK(allocator.tracker.deallocation_calls == 5);
 		CHECK(test_allocator_is_clean(&allocator.tracker));
 		CHECK(exfat_fixture_read_sector(&fixture, 0, boot_sector, sizeof(boot_sector)) == 0);
 		CHECK(exfat_resize_load_le16(boot_sector, sizeof(boot_sector), VOLUME_FLAGS_OFFSET,
@@ -1542,7 +1678,7 @@ static void test_allocator_failure_is_read_only(void)
 {
 	size_t failing_allocation;
 
-	for (failing_allocation = 1; failing_allocation <= 3; ++failing_allocation) {
+	for (failing_allocation = 1; failing_allocation <= 4; ++failing_allocation) {
 		struct allocator_state allocator = { 0 };
 		struct exfat_resize_options options;
 		struct exfat_fixture fixture;
@@ -1576,7 +1712,7 @@ static void test_directory_worklist_growth(void)
 	options = tracked_resize_options(&allocator);
 	error = exfat_fixture_resize(&fixture.memory.device, TARGET_SECTOR_COUNT, &options, NULL);
 	CHECK(error == EXFAT_RESIZE_SUCCESS);
-	CHECK(allocator.tracker.allocation_attempts > 4);
+	CHECK(allocator.tracker.allocation_attempts > 5);
 	CHECK(allocator.tracker.deallocation_calls == allocator.tracker.successful_allocations);
 	CHECK(test_allocator_is_clean(&allocator.tracker));
 	CHECK(!allocator.allocation_after_write);
@@ -1587,7 +1723,7 @@ static void test_directory_worklist_allocation_failure(void)
 {
 	size_t failing_allocation;
 
-	for (failing_allocation = 4; failing_allocation <= 6; ++failing_allocation) {
+	for (failing_allocation = 5; failing_allocation <= 7; ++failing_allocation) {
 		struct allocator_state allocator = { 0 };
 		struct exfat_resize_options options;
 		struct exfat_fixture fixture;
@@ -2011,62 +2147,67 @@ static void test_contiguous_relocation_is_batched(void)
 	}
 }
 
-static void test_bitmap_fat_stream_is_cached(void)
+static void test_source_fat_snapshot_is_single_read(void)
 {
 	struct exfat_resize_options options = resize_options();
 	struct exfat_fixture fixture;
 	enum exfat_resize_error error;
-	size_t first_fat_sector_reads;
 
 	CHECK(exfat_fixture_initialize(&fixture, TARGET_SECTOR_COUNT) == 0);
 	memory_block_device_clear_operations(&fixture.memory);
 	error = exfat_fixture_resize(&fixture.memory.device, TARGET_SECTOR_COUNT, &options, NULL);
 	CHECK(error == EXFAT_RESIZE_SUCCESS);
-	first_fat_sector_reads = preflight_read_count(&fixture, fixture.geometry.fat_offset, 1);
-	/*
-	 * The allocation-model and bitmap-chain caches each load this sector
-	 * once. Bitmap payload reads must not evict the bitmap's FAT sector.
-	 */
-	CHECK(first_fat_sector_reads <= 2);
+	check_source_fat_snapshot_read(&fixture);
 	exfat_fixture_destroy(&fixture);
 }
 
-static void test_directory_fat_streams_are_cached(void)
+static void test_file_fat_stream_uses_source_snapshot(void)
 {
-	const size_t rewrite_fat_limit =
-	    (PERFORMANCE_DIRECTORY_CLUSTER_COUNT + SECTOR_SIZE / 4 - 1) / (SECTOR_SIZE / 4) + 4;
-	struct exfat_resize_geometry target;
 	struct exfat_resize_options options = resize_options();
-	struct exfat_fixture fixture;
-	enum exfat_resize_error error;
-	uint64_t target_root_sector;
-	uint32_t target_root_cluster;
-	size_t preflight_fat_reads;
-	size_t rewrite_fat_reads;
+	int fragmented;
 
-	CHECK(exfat_fixture_initialize(&fixture, TARGET_SECTOR_COUNT) == 0);
-	CHECK(configure_fat_chained_root_directory(&fixture) == 0);
-	error = plan_fixture_growth(&fixture, TARGET_SECTOR_COUNT, &target);
-	CHECK(error == EXFAT_RESIZE_SUCCESS);
-	error = exfat_resize_map_growth_cluster(
-	    &fixture.geometry, &target, fixture.geometry.root_directory_cluster, &target_root_cluster);
-	CHECK(error == EXFAT_RESIZE_SUCCESS);
-	target_root_sector = exfat_fixture_cluster_sector(&target, target_root_cluster);
-	memory_block_device_clear_operations(&fixture.memory);
+	for (fragmented = 0; fragmented <= 1; ++fragmented) {
+		struct exfat_fixture fixture;
+		enum exfat_resize_error error;
 
-	error = exfat_fixture_resize(&fixture.memory.device, TARGET_SECTOR_COUNT, &options, NULL);
-	CHECK(error == EXFAT_RESIZE_SUCCESS);
-	preflight_fat_reads =
-	    preflight_read_count(&fixture, fixture.geometry.fat_offset, fixture.geometry.fat_length);
-	rewrite_fat_reads = rewrite_fat_read_count(&fixture, &target, target_root_sector);
-	/*
-	 * Validation has three independent FAT access patterns, so allow twice
-	 * the source FAT length. Sharing directory data and FAT storage would
-	 * instead add approximately one FAT read per directory cluster.
-	 */
-	CHECK(preflight_fat_reads <= (size_t)fixture.geometry.fat_length * 2);
-	CHECK(rewrite_fat_reads <= rewrite_fat_limit);
-	exfat_fixture_destroy(&fixture);
+		CHECK(exfat_fixture_initialize(&fixture, TARGET_SECTOR_COUNT) == 0);
+		CHECK(
+		    configure_fat_chained_file(&fixture, PERFORMANCE_FILE_CLUSTER_COUNT, fragmented) == 0);
+		error = exfat_fixture_resize(&fixture.memory.device, TARGET_SECTOR_COUNT, &options, NULL);
+		CHECK(error == EXFAT_RESIZE_SUCCESS);
+		check_source_fat_snapshot_read(&fixture);
+		exfat_fixture_destroy(&fixture);
+	}
+}
+
+static void test_directory_fat_stream_uses_source_snapshot_and_target_model(void)
+{
+	struct exfat_resize_options options = resize_options();
+	int fragmented;
+
+	for (fragmented = 0; fragmented <= 1; ++fragmented) {
+		struct exfat_resize_geometry target;
+		struct exfat_fixture fixture;
+		enum exfat_resize_error error;
+		uint64_t target_root_sector;
+		uint32_t target_root_cluster;
+
+		CHECK(exfat_fixture_initialize(&fixture, TARGET_SECTOR_COUNT) == 0);
+		CHECK(configure_fat_chained_root_directory(&fixture, fragmented) == 0);
+		error = plan_fixture_growth(&fixture, TARGET_SECTOR_COUNT, &target);
+		CHECK(error == EXFAT_RESIZE_SUCCESS);
+		error = exfat_resize_map_growth_cluster(&fixture.geometry, &target,
+		    fixture.geometry.root_directory_cluster, &target_root_cluster);
+		CHECK(error == EXFAT_RESIZE_SUCCESS);
+		target_root_sector = exfat_fixture_cluster_sector(&target, target_root_cluster);
+		memory_block_device_clear_operations(&fixture.memory);
+
+		error = exfat_fixture_resize(&fixture.memory.device, TARGET_SECTOR_COUNT, &options, NULL);
+		CHECK(error == EXFAT_RESIZE_SUCCESS);
+		check_source_fat_snapshot_read(&fixture);
+		CHECK(rewrite_fat_read_count(&fixture, &target, target_root_sector) == 0);
+		exfat_fixture_destroy(&fixture);
+	}
 }
 
 static void test_multi_sector_cluster_copy(void)
@@ -2165,7 +2306,7 @@ int main(void)
 	test_fat_boundary_geometry();
 	test_fat_padding_is_not_written();
 	test_preflight_is_read_only();
-	test_invalid_entry_checksum_does_not_direct_fat_reads();
+	test_invalid_entry_checksum_does_not_follow_fat();
 	test_stream_extension_structure_is_validated();
 	test_unsupported_directory_entries();
 	test_insufficient_growth_is_rejected();
@@ -2194,8 +2335,9 @@ int main(void)
 	test_options_validation();
 	test_mapping_extremes();
 	test_contiguous_relocation_is_batched();
-	test_bitmap_fat_stream_is_cached();
-	test_directory_fat_streams_are_cached();
+	test_source_fat_snapshot_is_single_read();
+	test_file_fat_stream_uses_source_snapshot();
+	test_directory_fat_stream_uses_source_snapshot_and_target_model();
 	test_multi_sector_cluster_copy();
 
 	if (failure_count != 0) {

--- a/tests/package/install_test.cmake.in
+++ b/tests/package/install_test.cmake.in
@@ -135,7 +135,8 @@ foreach(required_text
         "must not retry the resize"
         "requires the verified backup"
         "## Memory requirements"
-        "cache block containing seven filesystem sectors"
+        "snapshot of the used portion of the source FAT"
+        "cache block containing three filesystem sectors"
         "one 32-bit value per target cluster"
 )
     string(FIND "${transaction_contents}" "${required_text}" required_text_offset)


### PR DESCRIPTION
Snapshot the used source FAT for preflight lookups and release it before writing. Follow the allocation model during target directory rewrites and remove the obsolete FAT sector caches.

Add fragmented-chain I/O regressions and update the memory documentation.