### PR TITLE
Consolidate FAT sizing and library test labels

### DIFF
--- a/lib/boot_region.c
+++ b/lib/boot_region.c
@@ -122,7 +122,7 @@ static enum exfat_resize_error validate_boot_values(
 	uint64_t heap_end;
 	uint64_t available_clusters;
 	uint64_t expected_cluster_count;
-	uint64_t minimum_fat_sectors;
+	uint32_t minimum_fat_sectors;
 	uint64_t minimum_volume_sectors;
 
 	if (values->bytes_per_sector_shift < 9 || values->bytes_per_sector_shift > 12 ||
@@ -165,8 +165,7 @@ static enum exfat_resize_error validate_boot_values(
 	if (fat_end > geometry->cluster_heap_offset)
 		return EXFAT_RESIZE_INVALID_FILESYSTEM;
 
-	minimum_fat_sectors = ((uint64_t)geometry->cluster_count + 2) * 4;
-	minimum_fat_sectors = (minimum_fat_sectors + sector_size - 1) / sector_size;
+	minimum_fat_sectors = exfat_resize_used_fat_sector_count(geometry->cluster_count, sector_size);
 	if (geometry->fat_length < minimum_fat_sectors)
 		return EXFAT_RESIZE_INVALID_FILESYSTEM;
 

--- a/lib/geometry.c
+++ b/lib/geometry.c
@@ -8,6 +8,13 @@
 
 #define EXFAT_MAX_CLUSTER_COUNT (UINT32_MAX - UINT32_C(10))
 
+uint32_t exfat_resize_used_fat_sector_count(uint32_t cluster_count, uint32_t sector_size)
+{
+	uint64_t byte_count = ((uint64_t)cluster_count + 2) * 4;
+
+	return (uint32_t)((byte_count + sector_size - 1) / sector_size);
+}
+
 static int candidate_fits(const struct exfat_resize_device_geometry *device_geometry,
     const struct exfat_resize_geometry *source,
     uint64_t target_volume_sector_count,
@@ -15,20 +22,16 @@ static int candidate_fits(const struct exfat_resize_device_geometry *device_geom
     uint32_t *fat_length,
     uint32_t *cluster_heap_offset)
 {
-	const uint64_t sector_size = device_geometry->logical_sector_size;
+	const uint32_t sector_size = device_geometry->logical_sector_size;
 	const uint64_t sectors_per_cluster = source->sectors_per_cluster;
-	uint64_t candidate_fat_length;
+	uint32_t candidate_fat_length;
 	uint64_t candidate_heap_offset;
 	uint64_t fat_end;
 	uint64_t heap_movement;
 
-	candidate_fat_length = ((uint64_t)candidate_cluster_count + 2) * 4;
-	candidate_fat_length = (candidate_fat_length + sector_size - 1) / sector_size;
+	candidate_fat_length = exfat_resize_used_fat_sector_count(candidate_cluster_count, sector_size);
 	if (candidate_fat_length < source->fat_length)
 		candidate_fat_length = source->fat_length;
-	if (candidate_fat_length > UINT32_MAX)
-		return 0;
-
 	candidate_heap_offset = source->cluster_heap_offset;
 	fat_end = (uint64_t)source->fat_offset + candidate_fat_length;
 	if (fat_end > candidate_heap_offset) {
@@ -41,7 +44,7 @@ static int candidate_fits(const struct exfat_resize_device_geometry *device_geom
 	        (target_volume_sector_count - candidate_heap_offset) / sectors_per_cluster)
 		return 0;
 
-	*fat_length = (uint32_t)candidate_fat_length;
+	*fat_length = candidate_fat_length;
 	*cluster_heap_offset = (uint32_t)candidate_heap_offset;
 	return 1;
 }
@@ -53,7 +56,7 @@ static int target_geometry_is_consistent(const struct exfat_resize_device_geomet
 	uint64_t available_clusters;
 	uint64_t fat_end;
 	uint64_t heap_movement;
-	uint64_t minimum_fat_length;
+	uint32_t minimum_fat_length;
 
 	if (target->cluster_heap_offset < source->cluster_heap_offset ||
 	    target->volume_sector_count <= target->cluster_heap_offset)
@@ -67,9 +70,8 @@ static int target_geometry_is_consistent(const struct exfat_resize_device_geomet
 	if (fat_end > target->cluster_heap_offset)
 		return 0;
 
-	minimum_fat_length = ((uint64_t)target->cluster_count + 2) * 4;
-	minimum_fat_length = (minimum_fat_length + device_geometry->logical_sector_size - 1) /
-	    device_geometry->logical_sector_size;
+	minimum_fat_length = exfat_resize_used_fat_sector_count(
+	    target->cluster_count, device_geometry->logical_sector_size);
 	if (target->fat_length < minimum_fat_length)
 		return 0;
 

--- a/lib/geometry.h
+++ b/lib/geometry.h
@@ -18,6 +18,12 @@ struct exfat_resize_geometry {
 };
 
 /*
+ * Returns the sectors needed for FAT entries 0 through cluster_count + 1.
+ * sector_size must be a supported logical sector size.
+ */
+uint32_t exfat_resize_used_fat_sector_count(uint32_t cluster_count, uint32_t sector_size);
+
+/*
  * Calculates the largest geometry that fits target_volume_sector_count.
  *
  * device_geometry and source must already have been validated. This function

--- a/lib/resize.c
+++ b/lib/resize.c
@@ -229,13 +229,11 @@ static int cluster_is_valid(const struct exfat_resize_geometry *geometry, uint32
 static enum exfat_resize_error load_source_fat(struct resize_context *context)
 {
 	enum exfat_resize_error error;
-	uint64_t byte_count = ((uint64_t)context->source.cluster_count + 2) * 4;
-	uint64_t sector_count;
 	uint64_t allocation_size;
+	uint32_t sector_count;
 
-	error = exfat_resize_checked_ceil_divide_u64(byte_count, context->sector_size, &sector_count);
-	if (error != EXFAT_RESIZE_SUCCESS)
-		return error;
+	sector_count =
+	    exfat_resize_used_fat_sector_count(context->source.cluster_count, context->sector_size);
 	if (sector_count > context->source.fat_length)
 		return EXFAT_RESIZE_INVALID_FILESYSTEM;
 	error = exfat_resize_checked_multiply_u64(sector_count, context->sector_size, &allocation_size);
@@ -249,8 +247,8 @@ static enum exfat_resize_error load_source_fat(struct resize_context *context)
 	if (context->source_fat == NULL)
 		return EXFAT_RESIZE_OUT_OF_MEMORY;
 
-	return exfat_resize_block_device_read(context->device, context->source.fat_offset,
-	    (uint32_t)sector_count, context->source_fat, context->source_fat_size);
+	return exfat_resize_block_device_read(context->device, context->source.fat_offset, sector_count,
+	    context->source_fat, context->source_fat_size);
 }
 
 static enum exfat_resize_error source_fat_get(
@@ -1383,10 +1381,10 @@ static enum exfat_resize_error write_target_fat(struct resize_context *context)
 {
 	enum exfat_resize_error error;
 	uint64_t fat_sector = 0;
-	uint64_t fat_sector_count;
+	uint32_t fat_sector_count;
 
-	fat_sector_count = ((uint64_t)context->target.cluster_count + 2) * 4;
-	fat_sector_count = (fat_sector_count + context->sector_size - 1) / context->sector_size;
+	fat_sector_count =
+	    exfat_resize_used_fat_sector_count(context->target.cluster_count, context->sector_size);
 	if (fat_sector_count > context->target.fat_length)
 		return EXFAT_RESIZE_INTERNAL_ERROR;
 

--- a/tests/library/CMakeLists.txt
+++ b/tests/library/CMakeLists.txt
@@ -22,6 +22,7 @@ function(exfat_resize_add_library_test target test_name)
         NAME ${test_name}
         COMMAND ${target}
     )
+    set_tests_properties(${test_name} PROPERTIES LABELS library)
 endfunction()
 
 exfat_resize_add_library_test(
@@ -70,15 +71,4 @@ exfat_resize_add_library_test(
     support/memory_block_device.c
     support/test_allocator.c
     integration/transaction_tests.c
-)
-
-set_tests_properties(
-    library.foundation
-    library.boot_region
-    library.geometry
-    library.resize
-    library.api
-    library.transaction
-    PROPERTIES
-        LABELS library
 )


### PR DESCRIPTION
Centralize the used-FAT sector count calculation and use the bounded 32-bit result throughout its call sites.

Apply the library CTest label when each test is registered, removing the separately maintained test-name list.