### PR TITLE
Test File entry metadata preservation

### DIFF
--- a/tests/library/integration/resize_tests.c
+++ b/tests/library/integration/resize_tests.c
@@ -321,6 +321,8 @@ static int configure_checksum_wrap_entry_set(struct exfat_fixture *fixture)
 
 	if (exfat_fixture_read_sector(fixture, child_sector, child, sizeof(child)) != 0)
 		return -1;
+	/* The checksum-wrap prefix assumes an otherwise zeroed File primary. */
+	memset(child + 4, 0, 28);
 	child[1] = 3;
 	vendor = child + 32 * 3;
 	memset(vendor, 0, 32);
@@ -763,6 +765,29 @@ static unsigned char expected_cluster_byte(uint32_t source_cluster, uint64_t clu
 	return (unsigned char)(((uint64_t)source_cluster * 131 + cluster_byte_offset * 29) % 251 + 1);
 }
 
+static void check_file_primary_entries_preserved(
+    const unsigned char source[SECTOR_SIZE], const unsigned char target[SECTOR_SIZE])
+{
+	size_t entry_offset;
+	size_t byte_offset;
+	int saw_file = 0;
+
+	for (entry_offset = 0; entry_offset < SECTOR_SIZE; entry_offset += 32) {
+		int source_is_file = source[entry_offset] == ENTRY_FILE;
+		int target_is_file = target[entry_offset] == ENTRY_FILE;
+
+		CHECK(source_is_file == target_is_file);
+		if (!source_is_file)
+			continue;
+		saw_file = 1;
+		for (byte_offset = 0; byte_offset < 32; ++byte_offset) {
+			if (byte_offset != 2 && byte_offset != 3)
+				CHECK(source[entry_offset + byte_offset] == target[entry_offset + byte_offset]);
+		}
+	}
+	CHECK(saw_file);
+}
+
 static void check_cluster_pattern(struct exfat_fixture *fixture,
     const struct exfat_resize_geometry *geometry,
     uint32_t source_cluster,
@@ -792,7 +817,10 @@ static void test_resize(void)
 	struct exfat_resize_options options;
 	struct exfat_fixture fixture;
 	unsigned char workspace[SECTOR_SIZE * 2 + 13];
+	unsigned char source_root[SECTOR_SIZE];
+	unsigned char source_child[SECTOR_SIZE];
 	unsigned char root[SECTOR_SIZE];
+	unsigned char child[SECTOR_SIZE];
 	enum exfat_resize_error error;
 	uint32_t mapped;
 	uint32_t bitmap_cluster;
@@ -804,6 +832,12 @@ static void test_resize(void)
 	uint32_t next_cluster;
 
 	CHECK(exfat_fixture_initialize(&fixture, TARGET_SECTOR_COUNT + 1) == 0);
+	CHECK(exfat_fixture_read_sector(&fixture,
+	          exfat_fixture_cluster_sector(
+	              &fixture.geometry, fixture.geometry.root_directory_cluster),
+	          source_root, sizeof(source_root)) == 0);
+	CHECK(exfat_fixture_read_sector(&fixture, exfat_fixture_cluster_sector(&fixture.geometry, 6),
+	          source_child, sizeof(source_child)) == 0);
 	error = plan_fixture_growth(&fixture, TARGET_SECTOR_COUNT, &target);
 	CHECK(error == EXFAT_RESIZE_SUCCESS);
 	CHECK(target.cluster_heap_offset > fixture.geometry.cluster_heap_offset);
@@ -831,6 +865,7 @@ static void test_resize(void)
 	CHECK(mapped == target.root_directory_cluster);
 	CHECK(exfat_fixture_read_sector(
 	          &fixture, exfat_fixture_cluster_sector(&target, mapped), root, sizeof(root)) == 0);
+	check_file_primary_entries_preserved(source_root, root);
 	CHECK(root[0] == 0x81);
 	CHECK(exfat_resize_load_le32(root, sizeof(root), 20, &bitmap_cluster) == EXFAT_RESIZE_SUCCESS);
 	CHECK(exfat_resize_load_le64(root, sizeof(root), 24, &bitmap_length) == EXFAT_RESIZE_SUCCESS);
@@ -839,6 +874,12 @@ static void test_resize(void)
 	CHECK(
 	    exfat_resize_load_le32(root + 32, sizeof(root) - 32, 20, &mapped) == EXFAT_RESIZE_SUCCESS);
 	check_cluster_marker(&fixture, &target, mapped, 0x44);
+
+	error = exfat_resize_map_growth_cluster(&fixture.geometry, &target, 6, &mapped);
+	CHECK(error == EXFAT_RESIZE_SUCCESS);
+	CHECK(exfat_fixture_read_sector(
+	          &fixture, exfat_fixture_cluster_sector(&target, mapped), child, sizeof(child)) == 0);
+	check_file_primary_entries_preserved(source_child, child);
 
 	error = exfat_resize_map_growth_cluster(&fixture.geometry, &target, 5, &mapped);
 	CHECK(error == EXFAT_RESIZE_SUCCESS);

--- a/tests/library/support/exfat_fixture.c
+++ b/tests/library/support/exfat_fixture.c
@@ -35,7 +35,21 @@ enum {
 	ENTRY_FILE_NAME = 0xc1,
 	NO_FAT_CHAIN = 0x02,
 	ALLOCATION_POSSIBLE = 0x01,
-	DIRECTORY_ATTRIBUTE = 0x10
+	READ_ONLY_ATTRIBUTE = 0x01,
+	HIDDEN_ATTRIBUTE = 0x02,
+	SYSTEM_ATTRIBUTE = 0x04,
+	DIRECTORY_ATTRIBUTE = 0x10,
+	ARCHIVE_ATTRIBUTE = 0x20,
+
+	FILE_ATTRIBUTES_OFFSET = 4,
+	FILE_CREATE_TIMESTAMP_OFFSET = 8,
+	FILE_MODIFIED_TIMESTAMP_OFFSET = 12,
+	FILE_ACCESS_TIMESTAMP_OFFSET = 16,
+	FILE_CREATE_INCREMENT_OFFSET = 20,
+	FILE_MODIFIED_INCREMENT_OFFSET = 21,
+	FILE_CREATE_UTC_OFFSET = 22,
+	FILE_MODIFIED_UTC_OFFSET = 23,
+	FILE_ACCESS_UTC_OFFSET = 24
 };
 
 static uint32_t boot_checksum_byte(uint32_t checksum, unsigned char value)
@@ -60,6 +74,19 @@ static uint16_t entry_set_checksum(const unsigned char entries[ENTRY_SIZE * 3])
 			checksum = entry_checksum_byte(checksum, entries[index]);
 	}
 	return checksum;
+}
+
+static uint32_t file_timestamp(unsigned int seed)
+{
+	uint32_t year = 2026 - 1980;
+	uint32_t month = seed % 12 + 1;
+	uint32_t day = seed % 28 + 1;
+	uint32_t hour = seed % 24;
+	uint32_t minute = seed % 60;
+	uint32_t double_second = seed % 30;
+
+	return (year << 25) | (month << 21) | (day << 16) | (hour << 11) | (minute << 5) |
+	    double_second;
 }
 
 static int write_sectors(
@@ -309,8 +336,20 @@ static int append_file_set(unsigned char directory[SECTOR_SIZE],
 	entries = directory + *offset;
 	entries[0] = ENTRY_FILE;
 	entries[1] = 2;
-	if (exfat_resize_store_le16(entries, ENTRY_SIZE, 4, attributes) != EXFAT_RESIZE_SUCCESS)
+	if (exfat_resize_store_le16(entries, ENTRY_SIZE, FILE_ATTRIBUTES_OFFSET, attributes) !=
+	        EXFAT_RESIZE_SUCCESS ||
+	    exfat_resize_store_le32(entries, ENTRY_SIZE, FILE_CREATE_TIMESTAMP_OFFSET,
+	        file_timestamp(name)) != EXFAT_RESIZE_SUCCESS ||
+	    exfat_resize_store_le32(entries, ENTRY_SIZE, FILE_MODIFIED_TIMESTAMP_OFFSET,
+	        file_timestamp((unsigned int)name + 31)) != EXFAT_RESIZE_SUCCESS ||
+	    exfat_resize_store_le32(entries, ENTRY_SIZE, FILE_ACCESS_TIMESTAMP_OFFSET,
+	        file_timestamp((unsigned int)name + 67)) != EXFAT_RESIZE_SUCCESS)
 		return -1;
+	entries[FILE_CREATE_INCREMENT_OFFSET] = (unsigned char)((unsigned int)name % 200);
+	entries[FILE_MODIFIED_INCREMENT_OFFSET] = (unsigned char)(((unsigned int)name + 73) % 200);
+	entries[FILE_CREATE_UTC_OFFSET] = (unsigned char)(0x80 | ((unsigned int)name % 8));
+	entries[FILE_MODIFIED_UTC_OFFSET] = (unsigned char)(0x80 | (((unsigned int)name + 3) % 8));
+	entries[FILE_ACCESS_UTC_OFFSET] = (unsigned char)(0x80 | (((unsigned int)name + 6) % 8));
 
 	entries[ENTRY_SIZE] = ENTRY_STREAM;
 	entries[ENTRY_SIZE + 1] = ALLOCATION_POSSIBLE | (no_fat_chain ? NO_FAT_CHAIN : 0);
@@ -432,18 +471,21 @@ static int initialize_directories(struct exfat_fixture *fixture)
 		return -1;
 	offset += ENTRY_SIZE;
 
-	if (append_file_set(root, &offset, 0, 5, SECTOR_SIZE, 1, 'A') != 0 ||
+	if (append_file_set(root, &offset, ARCHIVE_ATTRIBUTE, 5, SECTOR_SIZE, 1, 'A') != 0 ||
 	    append_file_set(root, &offset, DIRECTORY_ATTRIBUTE, 6, SECTOR_SIZE, 1, 'D') != 0 ||
-	    append_file_set(root, &offset, 0, fixture->crossing_first_cluster,
+	    append_file_set(root, &offset, ARCHIVE_ATTRIBUTE | READ_ONLY_ATTRIBUTE,
+	        fixture->crossing_first_cluster,
 	        (uint64_t)fixture->crossing_cluster_count * fixture->geometry.sectors_per_cluster *
 	            SECTOR_SIZE,
 	        1, 'C') != 0 ||
-	    append_file_set(root, &offset, 0, fixture->fragmented_clusters[0],
+	    append_file_set(root, &offset, ARCHIVE_ATTRIBUTE | HIDDEN_ATTRIBUTE,
+	        fixture->fragmented_clusters[0],
 	        (uint64_t)3 * fixture->geometry.sectors_per_cluster * SECTOR_SIZE, 0, 'F') != 0)
 		return -1;
 
 	offset = 0;
-	if (append_file_set(child, &offset, 0, 8, SECTOR_SIZE, 1, 'N') != 0)
+	if (append_file_set(
+	        child, &offset, ARCHIVE_ATTRIBUTE | SYSTEM_ATTRIBUTE, 8, SECTOR_SIZE, 1, 'N') != 0)
 		return -1;
 
 	if (write_sectors(fixture, exfat_fixture_cluster_sector(&fixture->geometry, 2), 1, root) != 0 ||


### PR DESCRIPTION
Populate synthetic File entries with distinct valid attributes and timestamps, then compare their primary entries before and after resize while excluding the rewritten SetChecksum.

Keep the checksum-wrap fixture's intentionally zeroed primary layout.