### PR TITLE
Automate signed GitHub releases and add a tested Linux binary archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 .github export-ignore
 .gitignore export-ignore
 .vscode export-ignore
+docs/MAINTAINER.md export-ignore
+AGENTS.md export-ignore

--- a/.github/workflows/linux-binary.yml
+++ b/.github/workflows/linux-binary.yml
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: MIT
+
+name: Linux binary
+
+on:
+  workflow_call:
+    inputs:
+      source_artifact_name:
+        description: Artifact containing the tested source archive
+        required: true
+        type: string
+      binary_artifact_name:
+        description: Artifact name for the tested Linux archive
+        required: true
+        type: string
+      expected_version:
+        description: Optional tag or version that the binary must match
+        required: false
+        default: ""
+        type: string
+      retention_days:
+        description: Artifact retention days; 0 uses the repository default
+        required: false
+        default: 0
+        type: number
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test (AlmaLinux 8.10, x86-64 glibc)
+    runs-on: ubuntu-latest
+    container: almalinux:8.10
+    timeout-minutes: 30
+    env:
+      EXPECTED_VERSION: ${{ inputs.expected_version }}
+
+    steps:
+      - name: Install build tools
+        run: |
+          dnf install --assumeyes \
+            binutils ca-certificates cmake diffutils findutils gcc gzip make tar
+
+      - name: Download tested source archive
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.source_artifact_name }}
+          path: source-artifacts
+
+      - name: Record builder environment
+        run: |
+          cat /etc/os-release
+          uname -a
+          getconf GNU_LIBC_VERSION
+          gcc --version
+          cmake --version
+          readelf --version
+
+      - name: Build and test Linux binary archive
+        run: |
+          set -eu
+          test "$(uname -m)" = x86_64
+          archive=$(find source-artifacts -maxdepth 1 -type f -name 'exfat-resize-*.tar.gz' -print)
+          test -n "$archive"
+          test "$(printf '%s\n' "$archive" | wc -l)" -eq 1
+
+          mkdir source-tree
+          tar -xzf "$archive" -C source-tree
+          source_directory=$(find source-tree -mindepth 1 -maxdepth 1 \
+            -type d -name 'exfat-resize-*' -print)
+          test -n "$source_directory"
+          test "$(printf '%s\n' "$source_directory" | wc -l)" -eq 1
+
+          if [ -n "$EXPECTED_VERSION" ]; then
+            expected_version=${EXPECTED_VERSION#v}
+            test "$(sed -n '1p' "$source_directory/.tarball-version")" = "$expected_version"
+          fi
+
+          "$source_directory/tools/build-linux-binary.sh" "$source_directory" linux-artifacts
+          binary_archive=$(find linux-artifacts -maxdepth 1 -type f \
+            -name 'exfat-resize-*-linux-x86_64-glibc.tar.gz' -print)
+          test -n "$binary_archive"
+          test "$(printf '%s\n' "$binary_archive" | wc -l)" -eq 1
+          "$source_directory/tests/package/linux-binary-test.sh" \
+            "$binary_archive" "$source_directory"
+
+      - name: Upload tested Linux archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.binary_artifact_name }}
+          path: linux-artifacts/exfat-resize-*-linux-x86_64-glibc.tar.gz
+          if-no-files-found: error
+          overwrite: true
+          retention-days: ${{ inputs.retention_days }}
+
+  compatibility:
+    name: Compatibility (${{ matrix.name }})
+    needs: build
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Debian 12
+            image: debian:12
+          - name: Ubuntu 22.04 LTS
+            image: ubuntu:22.04
+
+    steps:
+      - name: Install exFAT and archive tools
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+            ca-certificates exfatprogs findutils gzip tar
+
+      - name: Download tested Linux archive
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.binary_artifact_name }}
+          path: linux-artifacts
+
+      - name: Run regular-file resize compatibility test
+        run: |
+          set -eu
+          binary_archive=$(find linux-artifacts -maxdepth 1 -type f \
+            -name 'exfat-resize-*-linux-x86_64-glibc.tar.gz' -print)
+          test -n "$binary_archive"
+          test "$(printf '%s\n' "$binary_archive" | wc -l)" -eq 1
+
+          mkdir extracted
+          tar -xzf "$binary_archive" -C extracted --strip-components=1
+          binary=extracted/exfat-resize
+          "$binary" --version
+
+          image=compatibility-smoke.exfat
+          truncate -s 64M "$image"
+          mkfs.exfat "$image" >/dev/null
+          truncate -s 128M "$image"
+          "$binary" "$image"
+          fsck.exfat -n "$image"

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -66,11 +66,12 @@ jobs:
       - name: Upload source artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: source-release-${{ github.ref_name }}
+          name: source-release-${{ github.ref_name }}-${{ github.run_id }}
           path: |
             dist/${{ steps.artifacts.outputs.archive }}
             dist/${{ steps.artifacts.outputs.checksum }}
           if-no-files-found: error
+          overwrite: true
 
   publish_draft:
     name: Create draft release
@@ -84,7 +85,7 @@ jobs:
       - name: Download source artifacts
         uses: actions/download-artifact@v4
         with:
-          name: source-release-${{ github.ref_name }}
+          name: source-release-${{ github.ref_name }}-${{ github.run_id }}
           path: release-assets
 
       - name: Verify downloaded source artifacts
@@ -150,6 +151,4 @@ jobs:
           gh release download "$RELEASE_REF" \
             --dir downloaded-release-assets \
             --pattern "$archive" --pattern "$checksum"
-          cmp "release-assets/$archive" "downloaded-release-assets/$archive"
-          cmp "release-assets/$checksum" "downloaded-release-assets/$checksum"
           (cd downloaded-release-assets && sha256sum --check "$checksum")

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+
+name: Source release dry run
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_ref:
+        description: Existing release tag in the form vX.Y.Z
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  source-release:
+    name: Source release (${{ inputs.release_ref }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out release tooling
+        uses: actions/checkout@v6
+        with:
+          path: release-tools
+          persist-credentials: false
+
+      - name: Check out release source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_ref }}
+          fetch-depth: 0
+          fetch-tags: true
+          path: release-source
+          persist-credentials: false
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install --yes cmake g++
+
+      - name: Validate release tag and commit
+        env:
+          RELEASE_REF: ${{ inputs.release_ref }}
+        run: |
+          set -euo pipefail
+          release_commit=$(git -C release-source rev-parse --verify 'HEAD^{commit}')
+          release-tools/tools/release-check.sh \
+            --source-dir release-source "$RELEASE_REF" "$release_commit"
+
+      - name: Test release package
+        run: make -C release-source release-test
+
+      - name: Build source artifacts
+        run: make -C release-source dist
+
+      - name: Verify source artifacts
+        id: artifacts
+        env:
+          RELEASE_REF: ${{ inputs.release_ref }}
+        run: |
+          set -euo pipefail
+          version=${RELEASE_REF#v}
+          archive=exfat-resize-$version.tar.gz
+          checksum=$archive.sha256
+          cd release-source/dist
+          test -f "$archive"
+          test -f "$checksum"
+          sha256sum --check "$checksum"
+          printf 'archive=%s\n' "release-source/dist/$archive" >>"$GITHUB_OUTPUT"
+          printf 'checksum=%s\n' "release-source/dist/$checksum" >>"$GITHUB_OUTPUT"
+
+      - name: Upload source artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-release-${{ inputs.release_ref }}
+          path: |
+            ${{ steps.artifacts.outputs.archive }}
+            ${{ steps.artifacts.outputs.checksum }}
+          if-no-files-found: error

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-name: Source release
+name: Release
 
 on:
   push:
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: source-release-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -43,39 +43,42 @@ jobs:
             echo "release commit is not reachable from $DEFAULT_BRANCH" >&2
             exit 1
           fi
-          tools/release-check.sh --require-signed-tag \
-            "$RELEASE_REF" "$release_commit"
+          tools/release-check.sh --require-signed-tag "$RELEASE_REF" "$release_commit"
 
       - name: Test release package
         run: make release-test
 
-      - name: Verify source artifacts
+      - name: Verify source archive
         id: artifacts
         run: |
           set -euo pipefail
           version=${RELEASE_REF#v}
           archive=exfat-resize-$version.tar.gz
-          checksum=$archive.sha256
-          cd dist
-          test -f "$archive"
-          test -f "$checksum"
-          sha256sum --check "$checksum"
+          test -f "dist/$archive"
           printf 'archive=%s\n' "$archive" >>"$GITHUB_OUTPUT"
-          printf 'checksum=%s\n' "$checksum" >>"$GITHUB_OUTPUT"
 
-      - name: Upload source artifacts
+      - name: Upload tested source archive
         uses: actions/upload-artifact@v4
         with:
           name: source-release-${{ github.ref_name }}-${{ github.run_id }}
-          path: |
-            dist/${{ steps.artifacts.outputs.archive }}
-            dist/${{ steps.artifacts.outputs.checksum }}
+          path: dist/${{ steps.artifacts.outputs.archive }}
           if-no-files-found: error
           overwrite: true
 
+  build_linux:
+    name: Linux binary archive
+    needs: build_source
+    permissions:
+      contents: read
+    uses: ./.github/workflows/linux-binary.yml
+    with:
+      source_artifact_name: source-release-${{ github.ref_name }}-${{ github.run_id }}
+      binary_artifact_name: linux-release-${{ github.ref_name }}-${{ github.run_id }}
+      expected_version: ${{ github.ref_name }}
+
   publish_draft:
     name: Create draft release
-    needs: build_source
+    needs: [build_source, build_linux]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -88,22 +91,27 @@ jobs:
           name: source-release-${{ github.ref_name }}-${{ github.run_id }}
           path: release-assets
 
-      - name: Verify downloaded source artifacts
+      - name: Download tested Linux archive
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-release-${{ github.ref_name }}-${{ github.run_id }}
+          path: release-assets
+
+      - name: Verify release asset names
         env:
           RELEASE_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           version=${RELEASE_REF#v}
-          archive=exfat-resize-$version.tar.gz
-          checksum=$archive.sha256
-          expected=$(printf '%s\n%s\n' "$archive" "$checksum" | sort)
+          source_archive=exfat-resize-$version.tar.gz
+          linux_archive=exfat-resize-$version-linux-x86_64-glibc.tar.gz
+          expected=$(printf '%s\n%s\n' "$source_archive" "$linux_archive" | sort)
           actual=$(find release-assets -maxdepth 1 -type f -printf '%f\n' | sort)
           if [ "$actual" != "$expected" ]; then
             echo "workflow artifact contains an unexpected file set" >&2
             printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
             exit 1
           fi
-          (cd release-assets && sha256sum --check "$checksum")
 
       - name: Create or update draft release
         env:
@@ -113,8 +121,8 @@ jobs:
         run: |
           set -euo pipefail
           version=${RELEASE_REF#v}
-          archive=exfat-resize-$version.tar.gz
-          checksum=$archive.sha256
+          source_archive=exfat-resize-$version.tar.gz
+          linux_archive=exfat-resize-$version-linux-x86_64-glibc.tar.gz
           title="exfat-resize $version"
 
           if is_draft=$(gh release view "$RELEASE_REF" \
@@ -125,8 +133,7 @@ jobs:
             fi
             gh release edit "$RELEASE_REF" --draft --title "$title" --verify-tag
           else
-            gh release create "$RELEASE_REF" --draft --generate-notes \
-              --title "$title" --verify-tag
+            gh release create "$RELEASE_REF" --draft --generate-notes --title "$title" --verify-tag
           fi
 
           gh release view "$RELEASE_REF" --json assets --jq '.assets[].name' |
@@ -136,19 +143,18 @@ jobs:
               fi
             done
           gh release upload "$RELEASE_REF" \
-            "release-assets/$archive" "release-assets/$checksum"
+            "release-assets/$source_archive" "release-assets/$linux_archive"
 
-          expected=$(printf '%s\n%s\n' "$archive" "$checksum" | sort)
-          actual=$(gh release view "$RELEASE_REF" --json assets \
-            --jq '.assets[].name' | sort)
+          api_endpoint=repos/$GH_REPO/releases/tags/$RELEASE_REF
+          expected=$(
+            for asset in "$source_archive" "$linux_archive"; do
+              digest=$(sha256sum "release-assets/$asset" | cut -d ' ' -f 1)
+              printf '%s\tsha256:%s\n' "$asset" "$digest"
+            done | sort
+          )
+          actual=$(gh api "$api_endpoint" --jq '.assets[] | [.name, .digest] | @tsv' | sort)
           if [ "$actual" != "$expected" ]; then
-            echo "draft release contains an unexpected asset set" >&2
+            echo "draft release asset names or digests do not match" >&2
             printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
             exit 1
           fi
-
-          mkdir downloaded-release-assets
-          gh release download "$RELEASE_REF" \
-            --dir downloaded-release-assets \
-            --pattern "$archive" --pattern "$checksum"
-          (cd downloaded-release-assets && sha256sum --check "$checksum")

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -3,12 +3,6 @@
 name: Source release dry run
 
 on:
-  # Temporary branch-only trigger; remove before merging into main.
-  push:
-    branches:
-      - improve-release-and-packaging
-    paths:
-      - .github/workflows/source-release.yml
   workflow_dispatch:
     inputs:
       release_ref:
@@ -21,11 +15,9 @@ permissions:
 
 jobs:
   source-release:
-    name: Source release (${{ github.event.inputs.release_ref || 'v1.0.1' }})
+    name: Source release (${{ inputs.release_ref }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      RELEASE_REF: ${{ github.event.inputs.release_ref || 'v1.0.1' }}
 
     steps:
       - name: Check out release tooling
@@ -37,7 +29,7 @@ jobs:
       - name: Check out release source
         uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ inputs.release_ref }}
           fetch-depth: 0
           fetch-tags: true
           path: release-source
@@ -47,6 +39,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install --yes cmake g++
 
       - name: Validate release tag and commit
+        env:
+          RELEASE_REF: ${{ inputs.release_ref }}
         run: |
           set -euo pipefail
           release_commit=$(git -C release-source rev-parse --verify 'HEAD^{commit}')
@@ -61,6 +55,8 @@ jobs:
 
       - name: Verify source artifacts
         id: artifacts
+        env:
+          RELEASE_REF: ${{ inputs.release_ref }}
         run: |
           set -euo pipefail
           version=${RELEASE_REF#v}
@@ -76,7 +72,7 @@ jobs:
       - name: Upload source artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: source-release-${{ env.RELEASE_REF }}
+          name: source-release-${{ inputs.release_ref }}
           path: |
             ${{ steps.artifacts.outputs.archive }}
             ${{ steps.artifacts.outputs.checksum }}

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -3,6 +3,12 @@
 name: Source release dry run
 
 on:
+  # Temporary branch-only trigger; remove before merging into main.
+  push:
+    branches:
+      - improve-release-and-packaging
+    paths:
+      - .github/workflows/source-release.yml
   workflow_dispatch:
     inputs:
       release_ref:
@@ -15,9 +21,11 @@ permissions:
 
 jobs:
   source-release:
-    name: Source release (${{ inputs.release_ref }})
+    name: Source release (${{ github.event.inputs.release_ref || 'v1.0.1' }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RELEASE_REF: ${{ github.event.inputs.release_ref || 'v1.0.1' }}
 
     steps:
       - name: Check out release tooling
@@ -29,7 +37,7 @@ jobs:
       - name: Check out release source
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release_ref }}
+          ref: ${{ env.RELEASE_REF }}
           fetch-depth: 0
           fetch-tags: true
           path: release-source
@@ -39,8 +47,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install --yes cmake g++
 
       - name: Validate release tag and commit
-        env:
-          RELEASE_REF: ${{ inputs.release_ref }}
         run: |
           set -euo pipefail
           release_commit=$(git -C release-source rev-parse --verify 'HEAD^{commit}')
@@ -55,8 +61,6 @@ jobs:
 
       - name: Verify source artifacts
         id: artifacts
-        env:
-          RELEASE_REF: ${{ inputs.release_ref }}
         run: |
           set -euo pipefail
           version=${RELEASE_REF#v}
@@ -72,7 +76,7 @@ jobs:
       - name: Upload source artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: source-release-${{ inputs.release_ref }}
+          name: source-release-${{ env.RELEASE_REF }}
           path: |
             ${{ steps.artifacts.outputs.archive }}
             ${{ steps.artifacts.outputs.checksum }}

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -1,38 +1,32 @@
 # SPDX-License-Identifier: MIT
 
-name: Source release dry run
+name: Source release
 
 on:
-  workflow_dispatch:
-    inputs:
-      release_ref:
-        description: Existing release tag in the form vX.Y.Z
-        required: true
-        type: string
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: read
 
+concurrency:
+  group: source-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  source-release:
-    name: Source release (${{ inputs.release_ref }})
+  build_source:
+    name: Build source release (${{ github.ref_name }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RELEASE_REF: ${{ github.ref_name }}
 
     steps:
-      - name: Check out release tooling
-        uses: actions/checkout@v6
-        with:
-          path: release-tools
-          persist-credentials: false
-
       - name: Check out release source
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release_ref }}
           fetch-depth: 0
-          fetch-tags: true
-          path: release-source
           persist-credentials: false
 
       - name: Install build tools
@@ -40,40 +34,122 @@ jobs:
 
       - name: Validate release tag and commit
         env:
-          RELEASE_REF: ${{ inputs.release_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          release_commit=$(git -C release-source rev-parse --verify 'HEAD^{commit}')
-          release-tools/tools/release-check.sh \
-            --source-dir release-source "$RELEASE_REF" "$release_commit"
+          release_commit=$(git rev-parse --verify 'HEAD^{commit}')
+          if ! git merge-base --is-ancestor \
+            "$release_commit" "refs/remotes/origin/$DEFAULT_BRANCH"; then
+            echo "release commit is not reachable from $DEFAULT_BRANCH" >&2
+            exit 1
+          fi
+          tools/release-check.sh --require-signed-tag \
+            "$RELEASE_REF" "$release_commit"
 
       - name: Test release package
-        run: make -C release-source release-test
-
-      - name: Build source artifacts
-        run: make -C release-source dist
+        run: make release-test
 
       - name: Verify source artifacts
         id: artifacts
-        env:
-          RELEASE_REF: ${{ inputs.release_ref }}
         run: |
           set -euo pipefail
           version=${RELEASE_REF#v}
           archive=exfat-resize-$version.tar.gz
           checksum=$archive.sha256
-          cd release-source/dist
+          cd dist
           test -f "$archive"
           test -f "$checksum"
           sha256sum --check "$checksum"
-          printf 'archive=%s\n' "release-source/dist/$archive" >>"$GITHUB_OUTPUT"
-          printf 'checksum=%s\n' "release-source/dist/$checksum" >>"$GITHUB_OUTPUT"
+          printf 'archive=%s\n' "$archive" >>"$GITHUB_OUTPUT"
+          printf 'checksum=%s\n' "$checksum" >>"$GITHUB_OUTPUT"
 
       - name: Upload source artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: source-release-${{ inputs.release_ref }}
+          name: source-release-${{ github.ref_name }}
           path: |
-            ${{ steps.artifacts.outputs.archive }}
-            ${{ steps.artifacts.outputs.checksum }}
+            dist/${{ steps.artifacts.outputs.archive }}
+            dist/${{ steps.artifacts.outputs.checksum }}
           if-no-files-found: error
+
+  publish_draft:
+    name: Create draft release
+    needs: build_source
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download source artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: source-release-${{ github.ref_name }}
+          path: release-assets
+
+      - name: Verify downloaded source artifacts
+        env:
+          RELEASE_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version=${RELEASE_REF#v}
+          archive=exfat-resize-$version.tar.gz
+          checksum=$archive.sha256
+          expected=$(printf '%s\n%s\n' "$archive" "$checksum" | sort)
+          actual=$(find release-assets -maxdepth 1 -type f -printf '%f\n' | sort)
+          if [ "$actual" != "$expected" ]; then
+            echo "workflow artifact contains an unexpected file set" >&2
+            printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+            exit 1
+          fi
+          (cd release-assets && sha256sum --check "$checksum")
+
+      - name: Create or update draft release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version=${RELEASE_REF#v}
+          archive=exfat-resize-$version.tar.gz
+          checksum=$archive.sha256
+          title="exfat-resize $version"
+
+          if is_draft=$(gh release view "$RELEASE_REF" \
+            --json isDraft --jq .isDraft 2>/dev/null); then
+            if [ "$is_draft" != true ]; then
+              echo "refusing to modify published release $RELEASE_REF" >&2
+              exit 1
+            fi
+            gh release edit "$RELEASE_REF" --draft --title "$title" --verify-tag
+          else
+            gh release create "$RELEASE_REF" --draft --generate-notes \
+              --title "$title" --verify-tag
+          fi
+
+          gh release view "$RELEASE_REF" --json assets --jq '.assets[].name' |
+            while IFS= read -r asset; do
+              if [ -n "$asset" ]; then
+                gh release delete-asset "$RELEASE_REF" "$asset" --yes
+              fi
+            done
+          gh release upload "$RELEASE_REF" \
+            "release-assets/$archive" "release-assets/$checksum"
+
+          expected=$(printf '%s\n%s\n' "$archive" "$checksum" | sort)
+          actual=$(gh release view "$RELEASE_REF" --json assets \
+            --jq '.assets[].name' | sort)
+          if [ "$actual" != "$expected" ]; then
+            echo "draft release contains an unexpected asset set" >&2
+            printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+            exit 1
+          fi
+
+          mkdir downloaded-release-assets
+          gh release download "$RELEASE_REF" \
+            --dir downloaded-release-assets \
+            --pattern "$archive" --pattern "$checksum"
+          cmp "release-assets/$archive" "downloaded-release-assets/$archive"
+          cmp "release-assets/$checksum" "downloaded-release-assets/$checksum"
+          (cd downloaded-release-assets && sha256sum --check "$checksum")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,3 +177,22 @@ jobs:
 
       - name: Build and test the release package
         run: CC=${{ matrix.cc }} CXX=${{ matrix.cxx }} make release-test
+
+      - name: Upload source package for Linux binary build
+        if: matrix.name == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-ci-${{ github.run_id }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  linux-binary:
+    name: Linux binary archive
+    needs: release-package
+    uses: ./.github/workflows/linux-binary.yml
+    with:
+      source_artifact_name: source-ci-${{ github.run_id }}
+      binary_artifact_name: linux-binary-ci-${{ github.run_id }}
+      retention_days: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,9 @@ Use `clang-format` from `PATH` when available. On macOS, if it is not in
 `PATH`, use:
 
 `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-format`
+
+After making changes to `.sh` files, format them with the same 100-character
+line limit configured in `.clang-format`. Keep commands and conditions on one
+line when they fit within that limit, and wrap them only when necessary. Apply
+the same rule to shell code in YAML `run` blocks, counting the YAML indentation
+toward the line limit.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,8 @@ install(
         exfat_resizeTargets
     ARCHIVE DESTINATION
         ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT
+        Development
 )
 
 if(EXFAT_RESIZE_BUILD_CLI)
@@ -186,12 +188,16 @@ if(EXFAT_RESIZE_BUILD_CLI)
             exfat-resize
         RUNTIME DESTINATION
             ${CMAKE_INSTALL_BINDIR}
+        COMPONENT
+            Runtime
     )
     install(
         FILES
             ${CMAKE_CURRENT_BINARY_DIR}/exfat-resize.8
         DESTINATION
             ${CMAKE_INSTALL_MANDIR}/man8
+        COMPONENT
+            Runtime
     )
 endif()
 
@@ -200,6 +206,8 @@ install(
         include/exfat_resize.h
     DESTINATION
         ${CMAKE_INSTALL_INCLUDEDIR}
+    COMPONENT
+        Development
 )
 
 install(
@@ -208,6 +216,8 @@ install(
         README.md
     DESTINATION
         ${CMAKE_INSTALL_DOCDIR}
+    COMPONENT
+        Runtime
 )
 
 install(
@@ -215,6 +225,8 @@ install(
         docs/TRANSACTION.md
     DESTINATION
         ${CMAKE_INSTALL_DOCDIR}/docs
+    COMPONENT
+        Runtime
 )
 
 install(
@@ -224,6 +236,8 @@ install(
         exfat_resize::
     DESTINATION
         ${CMAKE_INSTALL_LIBDIR}/cmake/exfat_resize
+    COMPONENT
+        Development
 )
 
 install(
@@ -232,6 +246,8 @@ install(
         ${CMAKE_CURRENT_BINARY_DIR}/exfat_resizeConfigVersion.cmake
     DESTINATION
         ${CMAKE_INSTALL_LIBDIR}/cmake/exfat_resize
+    COMPONENT
+        Development
 )
 
 if(EXFAT_RESIZE_BUILD_TESTS)

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ cli-sanitize-test: sanitize-build
 	$(CTEST) --test-dir "$(SANITIZE_BUILD)" -L cli --output-on-failure
 
 release-test:
+	tests/package/release-check.sh
 	tests/package/release-package.sh
 
 dist: VERSION cmake/ExfatResizeVersion.cmake tools/make-dist.sh tools/version.cmake

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The install command may require elevated privileges depending on the destination
 prefix. Run `exfat-resize --help` for a usage summary or `man exfat-resize` for
 the complete command-line reference.
 
+For a prebuilt Linux CLI, see [Binary install](#binary-install).
+
 For a Windows library build, see [Windows](#windows) under Build and test.
 
 ## Safety
@@ -237,3 +239,38 @@ includes only the library and its tests by default:
     cmake --build build --config Release
     ctest --test-dir build --build-config Release --output-on-failure -L library
     cmake --install build --config Release
+
+## Binary install
+
+GitHub Releases provide a prebuilt CLI archive expected to run on all conventional
+`x86_64` Linux distributions using glibc 2.28 or newer. It is built on
+AlmaLinux 8.10 and tested by performing an exFAT resize on Debian 12 and Ubuntu
+22.04 LTS. Musl-based distributions such as Alpine, non-FHS systems such as
+NixOS, and other CPU architectures require a different build or compatibility
+setup.
+
+Download `exfat-resize-X.Y.Z-linux-x86_64-glibc.tar.gz` from the corresponding
+[GitHub Release](https://github.com/huven/exfat-resize/releases). GitHub displays
+an immutable SHA-256 digest beside the asset; compare it with the output of:
+
+    sha256sum exfat-resize-X.Y.Z-linux-x86_64-glibc.tar.gz
+
+Replace `X.Y.Z` below with the release version, then extract and install it:
+
+    tar -xzf exfat-resize-X.Y.Z-linux-x86_64-glibc.tar.gz
+    cd exfat-resize-X.Y.Z-linux-x86_64-glibc
+    sudo ./install.sh
+
+The installer defaults to `/usr/local`. To use another absolute prefix, set
+`PREFIX`; elevated privileges are unnecessary when the destination is writable:
+
+    PREFIX=/your/prefix ./install.sh
+
+Use the same prefix and the `uninstall.sh` from the same release to remove the
+installed files:
+
+    sudo ./uninstall.sh
+
+For a custom prefix, remove it with:
+
+    PREFIX=/your/prefix ./uninstall.sh

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -25,8 +25,7 @@ to determine the committed version packaged by `make dist`.
 
 `make dist` packages committed `HEAD`, excluding uncommitted changes, and
 writes the source archive and its SHA-256 checksum to `dist/`. At an exact
-matching `vX.Y.Z` tag, the archive and CLI use `X.Y.Z`, and repeated archive
-builds produce byte-identical output. Untagged archives are development
-snapshots whose `git describe` identity also depends on the repository's `v*`
-tag namespace. The archive stores that identity in `.tarball-version` and the
-packaged commit ID in Git's tar metadata.
+matching `vX.Y.Z` tag, the archive and CLI use `X.Y.Z`. Untagged archives are
+development snapshots whose `git describe` identity also depends on the
+repository's `v*` tag namespace. The archive stores that identity in
+`.tarball-version` and the packaged commit ID in Git's tar metadata.

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -24,8 +24,67 @@ maintained version constant. `tools/version.cmake` uses the same implementation
 to determine the committed version packaged by `make dist`.
 
 `make dist` packages committed `HEAD`, excluding uncommitted changes, and
-writes the source archive and its SHA-256 checksum to `dist/`. At an exact
-matching `vX.Y.Z` tag, the archive and CLI use `X.Y.Z`. Untagged archives are
-development snapshots whose `git describe` identity also depends on the
-repository's `v*` tag namespace. The archive stores that identity in
-`.tarball-version` and the packaged commit ID in Git's tar metadata.
+writes the source archive to `dist/`. At an exact matching `vX.Y.Z` tag, the
+archive and CLI use `X.Y.Z`. Untagged archives are development snapshots whose
+`git describe` identity also depends on the repository's `v*` tag namespace.
+The archive stores that identity in `.tarball-version` and the packaged commit
+ID in Git's tar metadata.
+
+## Release procedure
+
+The routine release procedure has three steps:
+
+1. Update `VERSION` in a pull request, wait for all required checks, and merge
+   it to `main`.
+2. Check out the resulting release commit and create and push its signed
+   `vX.Y.Z` tag using the command below.
+3. Wait for the `Release` workflow, review its generated notes and the source
+   and Linux assets in the draft GitHub Release, then publish the draft
+   manually.
+
+The maintainer does not run `make dist`, create the GitHub Release, calculate
+checksums, or upload assets during a routine release.
+
+The workflow creates or updates a draft release; it never modifies an already
+published release. A failed run can therefore be rerun safely. Review the
+generated notes and assets before publishing the draft manually.
+
+## Creating a signed release tag
+
+New releases use an annotated tag signed with the dedicated SSH release key.
+After checking out the release commit and replacing `X.Y.Z` with the version
+from `VERSION`, create the tag with:
+
+    git -c gpg.format=ssh \
+        -c user.signingkey="$HOME/.ssh/id_github_sign" \
+        tag -s vX.Y.Z -m "exfat-resize X.Y.Z"
+
+This command uses the private key directly, prompting for its passphrase,
+and does not change the user's Git configuration. `-m` supplies the signed
+tag message; the command creates no commit. Push the resulting tag with:
+
+    git push origin vX.Y.Z
+
+The strict release preflight verifies tags against `tools/release-signers`. The
+authorized key currently has fingerprint
+`SHA256:wdqKZjZosJpyhXgEqSbyse2xhwZdqfk99mncJHzrycY`. The private key must not
+be committed, uploaded as a CI secret, or otherwise copied into CI.
+
+## Release preflight
+
+Release automation uses the read-only preflight check to validate the release
+tag and expected commit before building artifacts. Maintainers may run the
+same check locally when testing or diagnosing a release:
+
+    tools/release-check.sh [--source-dir SOURCE_DIR] \
+        [--require-signed-tag] vX.Y.Z COMMIT
+
+The check requires an existing exact `vX.Y.Z` tag, verifies that it resolves to
+the expected commit, compares the tag with the commit's `VERSION`, and requires
+the version helper to report a final build identity rather than a development
+identity. By default it accepts existing lightweight and annotated tags so
+historical releases remain testable. `--require-signed-tag` additionally
+requires an annotated SSH signature from a key in `tools/release-signers` and
+is intended for the publishing path. `--source-dir` allows release tooling
+from the current checkout to validate a separately checked-out tag; the signer
+allowlist still comes from the release-tooling checkout.

--- a/lib/boot_region.c
+++ b/lib/boot_region.c
@@ -330,8 +330,8 @@ enum exfat_resize_error exfat_resize_read_boot_regions(
     size_t work_buffer_size,
     struct exfat_resize_geometry *geometry)
 {
-	struct exfat_boot_values main;
-	struct exfat_boot_values backup;
+	struct exfat_boot_values main_values;
+	struct exfat_boot_values backup_values;
 	enum exfat_resize_error error;
 
 	if (device == NULL || work_buffer == NULL || geometry == NULL)
@@ -339,18 +339,18 @@ enum exfat_resize_error exfat_resize_read_boot_regions(
 	if (work_buffer_size < device->sector_size)
 		return EXFAT_RESIZE_INSUFFICIENT_WORKSPACE;
 
-	error =
-	    read_boot_region(device, EXFAT_MAIN_BOOT_REGION, 1, work_buffer, work_buffer_size, &main);
+	error = read_boot_region(
+	    device, EXFAT_MAIN_BOOT_REGION, 1, work_buffer, work_buffer_size, &main_values);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
 	error = read_boot_region(
-	    device, EXFAT_BACKUP_BOOT_REGION, 0, work_buffer, work_buffer_size, &backup);
+	    device, EXFAT_BACKUP_BOOT_REGION, 0, work_buffer, work_buffer_size, &backup_values);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
-	if (!boot_regions_are_consistent(&main, &backup))
+	if (!boot_regions_are_consistent(&main_values, &backup_values))
 		return EXFAT_RESIZE_INVALID_FILESYSTEM;
 
-	*geometry = main.geometry;
+	*geometry = main_values.geometry;
 	return EXFAT_RESIZE_SUCCESS;
 }
 

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+archive_directory=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+prefix=${PREFIX:-/usr/local}
+destdir=${DESTDIR:-}
+
+case $prefix in
+	/*) ;;
+	*)
+		echo "PREFIX must be an absolute path: $prefix" >&2
+		exit 1
+		;;
+esac
+case $destdir in
+	"" | /*) ;;
+	*)
+		echo "DESTDIR must be empty or an absolute path: $destdir" >&2
+		exit 1
+		;;
+esac
+
+install_root=$destdir$prefix
+mkdir -p "$install_root/bin" "$install_root/share/man/man8" "$install_root/share/doc/exfat-resize"
+mkdir -p "$install_root/share/doc/exfat-resize/docs"
+install -m 0755 "$archive_directory/exfat-resize" "$install_root/bin/exfat-resize"
+install -m 0644 "$archive_directory/exfat-resize.8" "$install_root/share/man/man8/exfat-resize.8"
+install -m 0644 "$archive_directory/LICENSE" "$install_root/share/doc/exfat-resize/LICENSE"
+install -m 0644 "$archive_directory/README.md" "$install_root/share/doc/exfat-resize/README.md"
+install -m 0644 "$archive_directory/docs/TRANSACTION.md" \
+	"$install_root/share/doc/exfat-resize/docs/TRANSACTION.md"
+
+echo "installed exfat-resize under $install_root"

--- a/packaging/linux/uninstall.sh
+++ b/packaging/linux/uninstall.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+prefix=${PREFIX:-/usr/local}
+destdir=${DESTDIR:-}
+
+case $prefix in
+	/*) ;;
+	*)
+		echo "PREFIX must be an absolute path: $prefix" >&2
+		exit 1
+		;;
+esac
+case $destdir in
+	"" | /*) ;;
+	*)
+		echo "DESTDIR must be empty or an absolute path: $destdir" >&2
+		exit 1
+		;;
+esac
+
+install_root=$destdir$prefix
+rm -f "$install_root/bin/exfat-resize" "$install_root/share/man/man8/exfat-resize.8" \
+	"$install_root/share/doc/exfat-resize/LICENSE" \
+	"$install_root/share/doc/exfat-resize/README.md" \
+	"$install_root/share/doc/exfat-resize/docs/TRANSACTION.md"
+rmdir "$install_root/share/doc/exfat-resize/docs" 2>/dev/null || true
+rmdir "$install_root/share/doc/exfat-resize" 2>/dev/null || true
+
+echo "removed exfat-resize from $install_root"

--- a/tests/package/CMakeLists.txt
+++ b/tests/package/CMakeLists.txt
@@ -21,3 +21,9 @@ add_test(
         -P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
 )
 set_tests_properties(package.version PROPERTIES LABELS package)
+
+add_test(
+    NAME package.release-check
+    COMMAND sh ${PROJECT_SOURCE_DIR}/tests/package/release-check.sh
+)
+set_tests_properties(package.release-check PROPERTIES LABELS package)

--- a/tests/package/linux-binary-test.sh
+++ b/tests/package/linux-binary-test.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+set -f
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 LINUX_ARCHIVE SOURCE_DIRECTORY" >&2
+	exit 2
+fi
+
+archive=$1
+source_directory=$2
+archive_directory=$(CDPATH= cd -- "$(dirname "$archive")" && pwd)
+archive_name=${archive##*/}
+archive=$archive_directory/$archive_name
+temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-linux-test.XXXXXX")
+
+cleanup() {
+	rm -rf "$temporary"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+case $archive_name in
+	exfat-resize-*-linux-x86_64-glibc.tar.gz) ;;
+	*)
+		echo "unexpected Linux archive name: $archive_name" >&2
+		exit 1
+		;;
+esac
+
+build_version=$(sed -n '1p' "$source_directory/.tarball-version")
+package=exfat-resize-$build_version-linux-x86_64-glibc
+if [ "$archive_name" != "$package.tar.gz" ]; then
+	echo "Linux archive and source build versions disagree" >&2
+	exit 1
+fi
+
+mkdir -p "$temporary/extracted" "$temporary/install-root"
+tar -xzf "$archive" -C "$temporary/extracted"
+package_directory=$temporary/extracted/$package
+top_level=$(find "$temporary/extracted" -mindepth 1 -maxdepth 1 -printf '%f\n')
+if [ "$top_level" != "$package" ] || [ ! -d "$package_directory" ]; then
+	echo "Linux archive has an unexpected top-level directory" >&2
+	exit 1
+fi
+expected=$(
+	printf '%s\n' LICENSE README.md docs exfat-resize exfat-resize.8 install.sh uninstall.sh |
+		sort
+)
+actual=$(find "$package_directory" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)
+if [ "$actual" != "$expected" ]; then
+	echo "Linux archive contains an unexpected file set" >&2
+	printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+	exit 1
+fi
+documentation=$(find "$package_directory/docs" -mindepth 1 -maxdepth 1 -printf '%f\n')
+if [ "$documentation" != TRANSACTION.md ]; then
+	echo "Linux archive contains an unexpected documentation file set" >&2
+	exit 1
+fi
+if [ "$(stat -c '%a' "$package_directory/exfat-resize")" != 755 ] ||
+	[ "$(stat -c '%a' "$package_directory/install.sh")" != 755 ] ||
+	[ "$(stat -c '%a' "$package_directory/uninstall.sh")" != 755 ]; then
+	echo "Linux archive executable modes are incorrect" >&2
+	exit 1
+fi
+if [ "$(stat -c '%a' "$package_directory/exfat-resize.8")" != 644 ] ||
+	[ "$(stat -c '%a' "$package_directory/LICENSE")" != 644 ] ||
+	[ "$(stat -c '%a' "$package_directory/README.md")" != 644 ] ||
+	[ "$(stat -c '%a' "$package_directory/docs/TRANSACTION.md")" != 644 ]; then
+	echo "Linux archive data-file modes are incorrect" >&2
+	exit 1
+fi
+if [ "$("$package_directory/exfat-resize" --version)" != "exfat-resize $build_version" ]; then
+	echo "archived CLI version is incorrect" >&2
+	exit 1
+fi
+if ! grep -F "exfat-resize $build_version" "$package_directory/exfat-resize.8" >/dev/null; then
+	echo "archived manual page has an incorrect version" >&2
+	exit 1
+fi
+cmp "$source_directory/LICENSE" "$package_directory/LICENSE"
+cmp "$source_directory/README.md" "$package_directory/README.md"
+cmp "$source_directory/docs/TRANSACTION.md" "$package_directory/docs/TRANSACTION.md"
+
+DESTDIR=$temporary/install-root "$package_directory/install.sh"
+install_prefix=$temporary/install-root/usr/local
+installed_binary=$install_prefix/bin/exfat-resize
+installed_manual=$install_prefix/share/man/man8/exfat-resize.8
+installed_license=$install_prefix/share/doc/exfat-resize/LICENSE
+installed_readme=$install_prefix/share/doc/exfat-resize/README.md
+installed_transaction=$install_prefix/share/doc/exfat-resize/docs/TRANSACTION.md
+if [ "$("$installed_binary" --version)" != "exfat-resize $build_version" ] ||
+	[ ! -f "$installed_manual" ] || [ ! -f "$installed_license" ] ||
+	[ ! -f "$installed_readme" ] || [ ! -f "$installed_transaction" ]; then
+	echo "installed Linux archive is incomplete" >&2
+	exit 1
+fi
+if [ "$(find "$install_prefix" -type f | wc -l)" -ne 5 ]; then
+	echo "installer created an unexpected file set" >&2
+	exit 1
+fi
+
+touch "$install_prefix/bin/unrelated" "$install_prefix/share/man/man8/unrelated.8" \
+	"$install_prefix/share/doc/exfat-resize/unrelated" \
+	"$install_prefix/share/doc/exfat-resize/docs/unrelated"
+DESTDIR=$temporary/install-root "$package_directory/uninstall.sh"
+if [ -e "$installed_binary" ] || [ -e "$installed_manual" ] || [ -e "$installed_license" ] ||
+	[ -e "$installed_readme" ] || [ -e "$installed_transaction" ]; then
+	echo "uninstaller left an installed project file behind" >&2
+	exit 1
+fi
+for unrelated in "$install_prefix/bin/unrelated" "$install_prefix/share/man/man8/unrelated.8" \
+	"$install_prefix/share/doc/exfat-resize/unrelated" \
+	"$install_prefix/share/doc/exfat-resize/docs/unrelated"; do
+	if [ ! -f "$unrelated" ]; then
+		echo "uninstaller removed an unrelated file: $unrelated" >&2
+		exit 1
+	fi
+done
+
+echo "Linux binary archive test: passed"

--- a/tests/package/release-check.sh
+++ b/tests/package/release-check.sh
@@ -7,6 +7,8 @@ set -f
 project_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
 temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-release-check.XXXXXX")
 repository=$temporary/repository
+signing_key=$temporary/release-signing-key
+other_signing_key=$temporary/other-signing-key
 
 cleanup() {
 	rm -rf "$temporary"
@@ -34,9 +36,19 @@ expect_rejected() {
 }
 
 trap cleanup EXIT HUP INT TERM
+if ! command -v ssh-keygen >/dev/null 2>&1; then
+	fail "ssh-keygen is required"
+fi
+ssh-keygen -q -t ed25519 -N "" -C "release check" -f "$signing_key"
+ssh-keygen -q -t ed25519 -N "" -C "other signer" -f "$other_signing_key"
+
 mkdir -p "$repository/tools"
 cp "$project_root/tools/release-check.sh" "$repository/tools/release-check.sh"
 cp "$project_root/tools/version.sh" "$repository/tools/version.sh"
+signing_public_key=$(cat "$signing_key.pub")
+printf '%s namespaces="git" %s\n' \
+	"release-check@example.invalid" "$signing_public_key" \
+	>"$repository/tools/release-signers"
 
 git -C "$repository" init --quiet
 git -C "$repository" config user.name "Release Check Test"
@@ -57,7 +69,36 @@ printf '%s\n' 2.0.0 >"$repository/VERSION"
 git -C "$repository" add VERSION
 git -C "$repository" commit --quiet -m "Release 2.0.0"
 commit_200=$(git -C "$repository" rev-parse --verify 'HEAD^{commit}')
-git -C "$repository" tag -a -m "Release 2.0.0" v2.0.0 "$commit_200"
+git -C "$repository" \
+	-c gpg.format=ssh -c user.signingkey="$signing_key" \
+	tag -s -m "Release 2.0.0" v2.0.0 "$commit_200"
+
+printf '%s\n' 2.1.0 >"$repository/VERSION"
+git -C "$repository" add VERSION
+git -C "$repository" commit --quiet -m "Release 2.1.0"
+commit_210=$(git -C "$repository" rev-parse --verify 'HEAD^{commit}')
+git -C "$repository" tag -a -m "Release 2.1.0" v2.1.0 "$commit_210"
+
+printf '%s\n' 2.2.0 >"$repository/VERSION"
+git -C "$repository" add VERSION
+git -C "$repository" commit --quiet -m "Release 2.2.0"
+commit_220=$(git -C "$repository" rev-parse --verify 'HEAD^{commit}')
+git -C "$repository" \
+	-c gpg.format=ssh -c user.signingkey="$other_signing_key" \
+	tag -s -m "Release 2.2.0" v2.2.0 "$commit_220"
+
+printf '%s\n' 2.3.0 >"$repository/VERSION"
+git -C "$repository" add VERSION
+git -C "$repository" commit --quiet -m "Release 2.3.0"
+commit_230=$(git -C "$repository" rev-parse --verify 'HEAD^{commit}')
+git -C "$repository" \
+	-c gpg.format=ssh -c user.signingkey="$signing_key" \
+	tag -s -m "Release 2.3.0" v2.3.0 "$commit_230"
+git -C "$repository" cat-file tag v2.3.0 | \
+	sed 's/^tag v2\.3\.0$/tag v2.3.1/' >"$temporary/invalid-tag"
+invalid_tag=$(git -C "$repository" hash-object -t tag -w \
+	"$temporary/invalid-tag")
+git -C "$repository" update-ref refs/tags/v2.3.1 "$invalid_tag"
 
 printf '%s\n' 3.0.0 >"$repository/VERSION"
 git -C "$repository" add VERSION
@@ -85,6 +126,27 @@ expected_output="release-check: v2.0.0 identifies $commit_200 as version 2.0.0"
 if [ "$annotated_output" != "$expected_output" ]; then
 	fail "annotated tag reported unexpected output: $annotated_output"
 fi
+
+signed_output=$(sh "$helper" --require-signed-tag v2.0.0 "$commit_200")
+if [ "$signed_output" != "$expected_output" ]; then
+	fail "signed tag reported unexpected output: $signed_output"
+fi
+
+expect_rejected signed-lightweight "release tag is not annotated: v1.2.3" \
+	sh "$helper" --require-signed-tag v1.2.3 "$commit_123"
+expect_rejected unsigned-annotated \
+	"release tag does not have a valid release signature: v2.1.0" \
+	sh "$helper" --require-signed-tag v2.1.0 "$commit_210"
+expect_rejected different-signer \
+	"release tag does not have a valid release signature: v2.2.0" \
+	sh "$helper" --require-signed-tag v2.2.0 "$commit_220"
+expect_rejected invalid-signature \
+	"release tag does not have a valid release signature: v2.3.1" \
+	sh "$helper" --require-signed-tag v2.3.1 "$commit_230"
+expect_rejected source-supplied-signer \
+	"release tag does not have a valid release signature: v2.0.0" \
+	sh "$external_helper" --source-dir "$repository" --require-signed-tag \
+	v2.0.0 "$commit_200"
 
 for malformed_tag in 1.2.3 v1.2 v1.2.3.4 v1..3 v1.2.x v1.2.3-rc1; do
 	expect_rejected "malformed-$malformed_tag" \

--- a/tests/package/release-check.sh
+++ b/tests/package/release-check.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+set -f
+
+project_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-release-check.XXXXXX")
+repository=$temporary/repository
+
+cleanup() {
+	rm -rf "$temporary"
+}
+
+fail() {
+	echo "release-check test: $*" >&2
+	exit 1
+}
+
+expect_rejected() {
+	name=$1
+	expected=$2
+	shift 2
+	log=$temporary/$name.log
+
+	if "$@" >"$log" 2>&1; then
+		fail "$name was accepted"
+	fi
+	if ! grep -F "$expected" "$log" >/dev/null; then
+		echo "release-check test: $name did not report: $expected" >&2
+		cat "$log" >&2
+		exit 1
+	fi
+}
+
+trap cleanup EXIT HUP INT TERM
+mkdir -p "$repository/tools"
+cp "$project_root/tools/release-check.sh" "$repository/tools/release-check.sh"
+cp "$project_root/tools/version.sh" "$repository/tools/version.sh"
+
+git -C "$repository" init --quiet
+git -C "$repository" config user.name "Release Check Test"
+git -C "$repository" config user.email "release-check@example.invalid"
+
+printf '%s\n' 1.2.3 >"$repository/VERSION"
+git -C "$repository" add VERSION tools
+git -C "$repository" commit --quiet -m "Release 1.2.3"
+commit_123=$(git -C "$repository" rev-parse --verify 'HEAD^{commit}')
+git -C "$repository" tag v1.2.3 "$commit_123"
+
+printf '%s\n' "same version, different commit" >"$repository/NOTES"
+git -C "$repository" add NOTES
+git -C "$repository" commit --quiet -m "Development change"
+other_commit=$(git -C "$repository" rev-parse --verify 'HEAD^{commit}')
+
+printf '%s\n' 2.0.0 >"$repository/VERSION"
+git -C "$repository" add VERSION
+git -C "$repository" commit --quiet -m "Release 2.0.0"
+commit_200=$(git -C "$repository" rev-parse --verify 'HEAD^{commit}')
+git -C "$repository" tag -a -m "Release 2.0.0" v2.0.0 "$commit_200"
+
+printf '%s\n' 3.0.0 >"$repository/VERSION"
+git -C "$repository" add VERSION
+git -C "$repository" commit --quiet -m "Mismatched release"
+commit_300=$(git -C "$repository" rev-parse --verify 'HEAD^{commit}')
+git -C "$repository" tag v3.0.1 "$commit_300"
+
+blob=$(printf '%s\n' "not a commit" | git -C "$repository" hash-object -w --stdin)
+git -C "$repository" tag v4.0.0 "$blob"
+
+git -C "$repository" status --short --untracked-files=all >"$temporary/status.before"
+git -C "$repository" show-ref >"$temporary/refs.before"
+
+helper=$repository/tools/release-check.sh
+lightweight_output=$(sh "$helper" v1.2.3 "$commit_123")
+expected_output="release-check: v1.2.3 identifies $commit_123 as version 1.2.3"
+if [ "$lightweight_output" != "$expected_output" ]; then
+	fail "lightweight tag reported unexpected output: $lightweight_output"
+fi
+
+external_helper=$project_root/tools/release-check.sh
+annotated_output=$(sh "$external_helper" --source-dir "$repository" \
+	v2.0.0 "$commit_200")
+expected_output="release-check: v2.0.0 identifies $commit_200 as version 2.0.0"
+if [ "$annotated_output" != "$expected_output" ]; then
+	fail "annotated tag reported unexpected output: $annotated_output"
+fi
+
+for malformed_tag in 1.2.3 v1.2 v1.2.3.4 v1..3 v1.2.x v1.2.3-rc1; do
+	expect_rejected "malformed-$malformed_tag" \
+		"invalid release tag: $malformed_tag" \
+		sh "$helper" "$malformed_tag" "$commit_123"
+done
+
+expect_rejected missing-tag "tag does not exist: v9.9.9" \
+	sh "$helper" v9.9.9 "$commit_300"
+expect_rejected non-commit-tag "tag does not identify a commit: v4.0.0" \
+	sh "$helper" v4.0.0 "$commit_300"
+expect_rejected invalid-commit "commit does not identify a commit: missing" \
+	sh "$helper" v1.2.3 missing
+expect_rejected wrong-target "not $other_commit" \
+	sh "$helper" v1.2.3 "$other_commit"
+expect_rejected version-mismatch \
+	"VERSION 3.0.0 does not match tag version 3.0.1" \
+	sh "$helper" v3.0.1 "$commit_300"
+expect_rejected missing-source \
+	"source directory not found: $temporary/missing" \
+	sh "$external_helper" --source-dir "$temporary/missing" \
+	v1.2.3 "$commit_123"
+
+git -C "$repository" status --short --untracked-files=all >"$temporary/status.after"
+git -C "$repository" show-ref >"$temporary/refs.after"
+if ! cmp -s "$temporary/status.before" "$temporary/status.after"; then
+	fail "helper modified the fixture working tree"
+fi
+if ! cmp -s "$temporary/refs.before" "$temporary/refs.after"; then
+	fail "helper modified the fixture refs"
+fi
+
+echo "release-check: passed"

--- a/tests/package/release-check.sh
+++ b/tests/package/release-check.sh
@@ -42,9 +42,11 @@ fi
 ssh-keygen -q -t ed25519 -N "" -C "release check" -f "$signing_key"
 ssh-keygen -q -t ed25519 -N "" -C "other signer" -f "$other_signing_key"
 
-mkdir -p "$repository/tools"
+mkdir -p "$repository/cmake" "$repository/tools"
+cp "$project_root/cmake/ExfatResizeVersion.cmake" \
+	"$repository/cmake/ExfatResizeVersion.cmake"
 cp "$project_root/tools/release-check.sh" "$repository/tools/release-check.sh"
-cp "$project_root/tools/version.sh" "$repository/tools/version.sh"
+cp "$project_root/tools/version.cmake" "$repository/tools/version.cmake"
 signing_public_key=$(cat "$signing_key.pub")
 printf '%s namespaces="git" %s\n' \
 	"release-check@example.invalid" "$signing_public_key" \
@@ -55,7 +57,7 @@ git -C "$repository" config user.name "Release Check Test"
 git -C "$repository" config user.email "release-check@example.invalid"
 
 printf '%s\n' 1.2.3 >"$repository/VERSION"
-git -C "$repository" add VERSION tools
+git -C "$repository" add VERSION cmake tools
 git -C "$repository" commit --quiet -m "Release 1.2.3"
 commit_123=$(git -C "$repository" rev-parse --verify 'HEAD^{commit}')
 git -C "$repository" tag v1.2.3 "$commit_123"

--- a/tests/package/release-package.sh
+++ b/tests/package/release-package.sh
@@ -62,7 +62,6 @@ else
 	(cd dist && shasum -a 256 -c "$archive_name.sha256")
 fi
 cp "$archive" "$temporary/reference.tar.gz"
-cp "$archive.sha256" "$temporary/reference.tar.gz.sha256"
 
 git clone --quiet --no-local "$project_root" "$temporary/dirty-helper-repository"
 printf '%s\n' '' 'This uncommitted line is intentional.' \
@@ -81,10 +80,15 @@ fi
 	cd "$temporary/dirty-helper-repository"
 	"$make_command" dist
 )
-cmp "$temporary/reference.tar.gz" \
-	"$temporary/dirty-helper-repository/$archive"
-cmp "$temporary/reference.tar.gz.sha256" \
-	"$temporary/dirty-helper-repository/$archive.sha256"
+dirty_archive=$temporary/dirty-helper-repository/$archive
+dirty_source=$temporary/dirty-source
+mkdir -p "$dirty_source"
+tar -xzf "$dirty_archive" -C "$dirty_source"
+if grep -F "This uncommitted line is intentional." \
+	"$dirty_source/exfat-resize-$build_version/README.md" >/dev/null; then
+	echo "release archive contains an uncommitted working-tree change" >&2
+	exit 1
+fi
 
 tar -xzf "$temporary/reference.tar.gz" -C "$temporary"
 source_tree=$temporary/exfat-resize-$build_version

--- a/tests/package/release-package.sh
+++ b/tests/package/release-package.sh
@@ -51,15 +51,9 @@ git status --short --untracked-files=all >"$temporary/status.before"
 package_version=$(cat build/dist/package-version)
 build_version=$(cat build/dist/build-version)
 archive=dist/exfat-resize-$build_version.tar.gz
-archive_name=${archive##*/}
-if [ ! -f "$archive" ] || [ ! -f "$archive.sha256" ]; then
-	echo "release archive or checksum is missing" >&2
+if [ ! -f "$archive" ]; then
+	echo "release archive is missing" >&2
 	exit 1
-fi
-if command -v sha256sum >/dev/null 2>&1; then
-	(cd dist && sha256sum -c "$archive_name.sha256")
-else
-	(cd dist && shasum -a 256 -c "$archive_name.sha256")
 fi
 cp "$archive" "$temporary/reference.tar.gz"
 

--- a/tools/build-linux-binary.sh
+++ b/tools/build-linux-binary.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+set -f
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 SOURCE_DIRECTORY OUTPUT_DIRECTORY" >&2
+	exit 2
+fi
+
+source_directory=$1
+output_directory=$2
+cmake_command=${CMAKE:-cmake}
+temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-linux-build.XXXXXX")
+
+cleanup() {
+	rm -rf "$temporary"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+if [ "$(uname -s)" != Linux ] || [ "$(uname -m)" != x86_64 ]; then
+	echo "Linux binary archives must be built on Linux x86_64" >&2
+	exit 1
+fi
+if [ ! -d "$source_directory" ]; then
+	echo "source directory does not exist: $source_directory" >&2
+	exit 1
+fi
+source_directory=$(CDPATH= cd -- "$source_directory" && pwd)
+if [ -e "$source_directory/.git" ]; then
+	echo "source directory must be an extracted, Git-free source archive" >&2
+	exit 1
+fi
+if [ ! -f "$source_directory/VERSION" ] || [ ! -f "$source_directory/.tarball-version" ]; then
+	echo "source archive version metadata is missing" >&2
+	exit 1
+fi
+
+package_version=$(sed -n '1p' "$source_directory/VERSION")
+build_version=$(sed -n '1p' "$source_directory/.tarball-version")
+if ! printf '%s\n' "$package_version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' >/dev/null; then
+	echo "invalid package version: $package_version" >&2
+	exit 1
+fi
+if ! printf '%s\n' "$build_version" | grep -E '^[0-9A-Za-z][0-9A-Za-z.+-]*$' >/dev/null; then
+	echo "invalid build version: $build_version" >&2
+	exit 1
+fi
+case $build_version in
+	"$package_version" | "$package_version"-*) ;;
+	*)
+		echo "package and build versions disagree" >&2
+		exit 1
+		;;
+esac
+if [ "${source_directory##*/}" != "exfat-resize-$build_version" ]; then
+	echo "source directory and build versions disagree" >&2
+	exit 1
+fi
+
+mkdir -p "$temporary/build" "$temporary/stage" "$output_directory"
+"$cmake_command" -S "$source_directory" -B "$temporary/build" -DCMAKE_BUILD_TYPE=Release \
+	-DEXFAT_RESIZE_BUILD_CLI=ON -DEXFAT_RESIZE_BUILD_TESTS=OFF
+"$cmake_command" --build "$temporary/build" --parallel --target exfat-resize
+"$cmake_command" --install "$temporary/build" --component Runtime \
+	--prefix "$temporary/stage/usr/local" --strip
+
+binary=$temporary/stage/usr/local/bin/exfat-resize
+manual=$temporary/stage/usr/local/share/man/man8/exfat-resize.8
+documentation=$temporary/stage/usr/local/share/doc/exfat_resize
+license=$documentation/LICENSE
+readme=$documentation/README.md
+transaction=$documentation/docs/TRANSACTION.md
+if [ ! -x "$binary" ] || [ ! -f "$manual" ] || [ ! -f "$license" ] ||
+	[ ! -f "$readme" ] || [ ! -f "$transaction" ]; then
+	echo "CMake runtime installation is incomplete" >&2
+	exit 1
+fi
+if [ "$("$binary" --version)" != "exfat-resize $build_version" ]; then
+	echo "built CLI version does not match the source archive" >&2
+	exit 1
+fi
+
+needed=$(LC_ALL=C readelf -d "$binary" |
+	sed -n 's/.*Shared library: \[\([^]]*\)\].*/\1/p')
+if [ "$needed" != libc.so.6 ]; then
+	echo "unexpected shared-library dependency set:" >&2
+	printf '%s\n' "$needed" >&2
+	exit 1
+fi
+interpreter=$(LC_ALL=C readelf -l "$binary" |
+	sed -n 's/.*Requesting program interpreter: \([^]]*\)\].*/\1/p')
+if [ "$interpreter" != /lib64/ld-linux-x86-64.so.2 ]; then
+	echo "unexpected ELF interpreter: $interpreter" >&2
+	exit 1
+fi
+glibc_versions=$(LC_ALL=C readelf --version-info "$binary" |
+	grep -o 'GLIBC_[0-9][0-9.]*' | sort -Vu)
+maximum_glibc=$(printf '%s\n' "$glibc_versions" | tail -n 1)
+newest_glibc=$(printf '%s\n%s\n' GLIBC_2.28 "$maximum_glibc" | sort -Vu | tail -n 1)
+if [ "$newest_glibc" != GLIBC_2.28 ]; then
+	echo "binary requires a glibc symbol newer than GLIBC_2.28:" >&2
+	printf '%s\n' "$glibc_versions" >&2
+	exit 1
+fi
+
+package=exfat-resize-$build_version-linux-x86_64-glibc
+package_directory=$temporary/$package
+mkdir -p "$package_directory/docs"
+install -m 0755 "$binary" "$package_directory/exfat-resize"
+install -m 0644 "$manual" "$package_directory/exfat-resize.8"
+install -m 0644 "$license" "$package_directory/LICENSE"
+install -m 0644 "$readme" "$package_directory/README.md"
+install -m 0644 "$transaction" "$package_directory/docs/TRANSACTION.md"
+install -m 0755 "$source_directory/packaging/linux/install.sh" "$package_directory/install.sh"
+install -m 0755 "$source_directory/packaging/linux/uninstall.sh" "$package_directory/uninstall.sh"
+
+archive=$package.tar.gz
+tar -czf "$output_directory/$archive" -C "$temporary" "$package"
+
+echo "built $output_directory/$archive"
+echo "maximum referenced glibc symbol: $maximum_glibc"

--- a/tools/make-dist.sh
+++ b/tools/make-dist.sh
@@ -29,11 +29,4 @@ git -c tar.umask=022 archive --format=tar --prefix="$package/" \
 gzip -n -9 -c <"$dist_build/$package.tar" >"$dist_build/$archive"
 mv "$dist_build/$archive" "$dist_output/$archive"
 
-if command -v sha256sum >/dev/null 2>&1; then
-	(cd "$dist_output" && sha256sum "$archive" > "$archive.sha256")
-else
-	(cd "$dist_output" && shasum -a 256 "$archive" > "$archive.sha256")
-fi
-
 echo "created $dist_output/$archive"
-echo "created $dist_output/$archive.sha256"

--- a/tools/release-check.sh
+++ b/tools/release-check.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+set -f
+
+usage() {
+	echo "usage: $0 [--source-dir SOURCE_DIR] TAG COMMIT" >&2
+	exit 2
+}
+
+fail() {
+	echo "release-check: $*" >&2
+	exit 1
+}
+
+validate_tag() {
+	value=$1
+	case $value in
+	v*)
+		version=${value#v}
+		;;
+	*)
+		fail "invalid release tag: $value"
+		;;
+	esac
+
+	case $version in
+	""|*[!0-9.]*)
+		fail "invalid release tag: $value"
+		;;
+	esac
+
+	old_ifs=$IFS
+	IFS=.
+	set -- $version
+	IFS=$old_ifs
+	if [ "$#" -ne 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+		fail "invalid release tag: $value"
+	fi
+
+	printf '%s\n' "$version"
+}
+
+case $# in
+2)
+	if ! source_dir=$(CDPATH= cd -- "$(dirname "$0")/.." 2>/dev/null && pwd); then
+		fail "could not determine the source directory"
+	fi
+	tag=$1
+	commit=$2
+	;;
+4)
+	if [ "$1" != "--source-dir" ]; then
+		usage
+	fi
+	if ! source_dir=$(CDPATH= cd -- "$2" 2>/dev/null && pwd); then
+		fail "source directory not found: $2"
+	fi
+	tag=$3
+	commit=$4
+	;;
+*)
+	usage
+esac
+
+tag_version=$(validate_tag "$tag")
+tag_ref=refs/tags/$tag
+
+if ! git -C "$source_dir" show-ref --verify --quiet "$tag_ref"; then
+	fail "tag does not exist: $tag"
+fi
+if ! tag_commit=$(git -C "$source_dir" rev-parse --verify \
+	"${tag_ref}^{commit}" 2>/dev/null); then
+	fail "tag does not identify a commit: $tag"
+fi
+if ! expected_commit=$(git -C "$source_dir" rev-parse --verify \
+	"${commit}^{commit}" 2>/dev/null); then
+	fail "commit does not identify a commit: $commit"
+fi
+if [ "$tag_commit" != "$expected_commit" ]; then
+	fail "tag $tag identifies $tag_commit, not $expected_commit"
+fi
+
+if ! package_version=$(git -C "$source_dir" show \
+	"${expected_commit}:VERSION" 2>/dev/null); then
+	fail "VERSION not found in commit $expected_commit"
+fi
+if [ "$package_version" != "$tag_version" ]; then
+	fail "VERSION $package_version does not match tag version $tag_version"
+fi
+
+if ! version_info=$(sh "$source_dir/tools/version.sh" --commit \
+	"$source_dir" "$expected_commit"); then
+	fail "could not determine the release version"
+fi
+resolved_package_version=$(printf '%s\n' "$version_info" | sed -n '1p')
+build_version=$(printf '%s\n' "$version_info" | sed -n '2p')
+if [ "$resolved_package_version" != "$tag_version" ]; then
+	fail "version helper reported package version $resolved_package_version, expected $tag_version"
+fi
+if [ "$build_version" != "$tag_version" ]; then
+	fail "version helper reported development build $build_version for tag $tag"
+fi
+
+printf 'release-check: %s identifies %s as version %s\n' \
+	"$tag" "$expected_commit" "$tag_version"

--- a/tools/release-check.sh
+++ b/tools/release-check.sh
@@ -5,7 +5,7 @@ set -eu
 set -f
 
 usage() {
-	echo "usage: $0 [--source-dir SOURCE_DIR] TAG COMMIT" >&2
+	echo "usage: $0 [--source-dir SOURCE_DIR] [--require-signed-tag] TAG COMMIT" >&2
 	exit 2
 }
 
@@ -42,33 +42,66 @@ validate_tag() {
 	printf '%s\n' "$version"
 }
 
-case $# in
-2)
-	if ! source_dir=$(CDPATH= cd -- "$(dirname "$0")/.." 2>/dev/null && pwd); then
-		fail "could not determine the source directory"
-	fi
-	tag=$1
-	commit=$2
-	;;
-4)
-	if [ "$1" != "--source-dir" ]; then
+if ! tool_root=$(CDPATH= cd -- "$(dirname "$0")/.." 2>/dev/null && pwd); then
+	fail "could not determine the release tooling directory"
+fi
+source_dir=$tool_root
+require_signed_tag=false
+
+while [ "$#" -gt 0 ]; do
+	case $1 in
+	--source-dir)
+		if [ "$#" -lt 2 ]; then
+			usage
+		fi
+		if ! source_dir=$(CDPATH= cd -- "$2" 2>/dev/null && pwd); then
+			fail "source directory not found: $2"
+		fi
+		shift 2
+		;;
+	--require-signed-tag)
+		require_signed_tag=true
+		shift
+		;;
+	--)
+		shift
+		break
+		;;
+	-*)
 		usage
-	fi
-	if ! source_dir=$(CDPATH= cd -- "$2" 2>/dev/null && pwd); then
-		fail "source directory not found: $2"
-	fi
-	tag=$3
-	commit=$4
-	;;
-*)
+		;;
+	*)
+		break
+		;;
+	esac
+done
+
+if [ "$#" -ne 2 ]; then
 	usage
-esac
+fi
+tag=$1
+commit=$2
 
 tag_version=$(validate_tag "$tag")
 tag_ref=refs/tags/$tag
 
 if ! git -C "$source_dir" show-ref --verify --quiet "$tag_ref"; then
 	fail "tag does not exist: $tag"
+fi
+if [ "$require_signed_tag" = true ]; then
+	if [ "$(git -C "$source_dir" cat-file -t "$tag_ref" 2>/dev/null)" != tag ]; then
+		fail "release tag is not annotated: $tag"
+	fi
+	signers=$tool_root/tools/release-signers
+	if [ ! -f "$signers" ]; then
+		fail "release signer allowlist not found: $signers"
+	fi
+	if ! git -C "$source_dir" \
+		-c gpg.format=ssh \
+		-c gpg.ssh.allowedSignersFile="$signers" \
+		verify-tag "$tag_ref" >/dev/null 2>&1; then
+		fail "release tag does not have a valid release signature: $tag"
+	fi
 fi
 if ! tag_commit=$(git -C "$source_dir" rev-parse --verify \
 	"${tag_ref}^{commit}" 2>/dev/null); then

--- a/tools/release-check.sh
+++ b/tools/release-check.sh
@@ -45,6 +45,7 @@ validate_tag() {
 if ! tool_root=$(CDPATH= cd -- "$(dirname "$0")/.." 2>/dev/null && pwd); then
 	fail "could not determine the release tooling directory"
 fi
+cmake_command=${CMAKE:-cmake}
 source_dir=$tool_root
 require_signed_tag=false
 
@@ -123,12 +124,26 @@ if [ "$package_version" != "$tag_version" ]; then
 	fail "VERSION $package_version does not match tag version $tag_version"
 fi
 
-if ! version_info=$(sh "$source_dir/tools/version.sh" --commit \
-	"$source_dir" "$expected_commit"); then
+if ! version_output=$(mktemp -d \
+	"${TMPDIR:-/tmp}/exfat-resize-release-check.XXXXXX"); then
+	fail "could not create temporary version output directory"
+fi
+cleanup() {
+	rm -rf "$version_output"
+}
+trap cleanup EXIT HUP INT TERM
+
+if ! "$cmake_command" \
+	"-DEXFAT_RESIZE_SOURCE_DIR=$source_dir" \
+	"-DEXFAT_RESIZE_COMMIT=$expected_commit" \
+	"-DEXFAT_RESIZE_VERSION_OUTPUT_DIR=$version_output" \
+	-P "$tool_root/tools/version.cmake"; then
 	fail "could not determine the release version"
 fi
-resolved_package_version=$(printf '%s\n' "$version_info" | sed -n '1p')
-build_version=$(printf '%s\n' "$version_info" | sed -n '2p')
+if ! resolved_package_version=$(cat "$version_output/package-version") ||
+	! build_version=$(cat "$version_output/build-version"); then
+	fail "version helper did not produce the expected output"
+fi
 if [ "$resolved_package_version" != "$tag_version" ]; then
 	fail "version helper reported package version $resolved_package_version, expected $tag_version"
 fi

--- a/tools/release-signers
+++ b/tools/release-signers
@@ -1,0 +1,1 @@
+richard@huveneers.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKZ/NipMDfgqN4WS73H/RckjAo3ir2LyzidXJ4d/S5eN github signing


### PR DESCRIPTION
## Summary

This PR reduces the routine release procedure to three maintainer actions:

1. Merge a pull request updating `VERSION`.
2. Create and push a signed `vX.Y.Z` tag.
3. Review and publish the draft GitHub Release created by CI.

The release contains:

- the existing source archive;
- generated release notes;
- a prebuilt `x86_64` Linux CLI archive for glibc-based distributions.

## Release automation

- Add a preflight check that validates the tag syntax, target commit, `VERSION`,
  build identity, and SSH signature.
- Keep the dedicated SSH signing key exclusively on the maintainer's machine.
- Build and test release artifacts in read-only jobs.
- Create or update the draft release in a separate publishing job.
- Refuse to modify an already published release.
- Compare locally calculated hashes with GitHub's immutable release-asset
  digests instead of publishing separate checksum files.

## Linux binary archive

- Build the CLI from the tested source archive on AlmaLinux 8.10 for an
  `x86_64` glibc 2.28 baseline.
- Verify its ELF loader, libc dependency, and referenced glibc symbol versions.
- Test the exact same archive by performing an exFAT resize on Debian 12 and
  Ubuntu 22.04 LTS.
- Include the CLI, manual page, license, README, transaction documentation, and
  small install and uninstall scripts.
- Add CMake runtime and development install components so the binary archive
  can stage only runtime files.

## Security model

Repository code and release artifacts are never executed in a job with
`contents: write`. The publishing job downloads already-tested artifacts but
does not check out or execute repository code. No personal access token or
private signing key is stored in CI.

## Validation

The hosted CI build, release-package tests, Linux archive tests, install and
uninstall tests, and Debian/Ubuntu compatibility tests are passing.

The only remaining end-to-end acceptance test is the next genuine signed
release tag after this PR is merged. That tag should produce the first complete
automated draft release for manual review and publication.