### PR TITLE
Reject unknown benign primary entries

### DIFF
--- a/lib/resize.c
+++ b/lib/resize.c
@@ -20,6 +20,7 @@ enum {
 	EXFAT_ENTRY_UPCASE = 0x82,
 	EXFAT_ENTRY_VOLUME_LABEL = 0x83,
 	EXFAT_ENTRY_FILE = 0x85,
+	EXFAT_ENTRY_VOLUME_GUID = 0xa0,
 	EXFAT_ENTRY_STREAM = 0xc0,
 	EXFAT_ENTRY_FILE_NAME = 0xc1,
 	EXFAT_ENTRY_VENDOR_EXTENSION = 0xe0,
@@ -47,6 +48,9 @@ enum {
 #define EXFAT_MODEL_NO_FAT_CHAIN UINT32_C(1)
 
 enum {
+	EXFAT_PRIMARY_SECONDARY_COUNT_OFFSET = 1,
+	EXFAT_PRIMARY_FLAGS_OFFSET = 4,
+
 	EXFAT_FILE_SECONDARY_COUNT_OFFSET = 1,
 	EXFAT_FILE_CHECKSUM_OFFSET = 2,
 	EXFAT_FILE_ATTRIBUTES_OFFSET = 4,
@@ -1112,27 +1116,6 @@ static enum exfat_resize_error scan_upcase_entry(struct resize_context *context,
 	return write_directory_entry(context, location, entry);
 }
 
-static enum exfat_resize_error scan_unknown_primary(
-    const unsigned char entry[EXFAT_DIRECTORY_ENTRY_SIZE])
-{
-	enum exfat_resize_error error;
-	uint16_t flags;
-	uint32_t first_cluster;
-
-	if ((entry[0] & EXFAT_ENTRY_BENIGN) == 0)
-		return EXFAT_RESIZE_UNSUPPORTED_CRITICAL_ENTRY;
-
-	error = exfat_resize_load_le16(entry, EXFAT_DIRECTORY_ENTRY_SIZE, 4, &flags);
-	if (error != EXFAT_RESIZE_SUCCESS)
-		return EXFAT_RESIZE_INVALID_FILESYSTEM;
-	if ((flags & EXFAT_ALLOCATION_POSSIBLE) == 0)
-		return EXFAT_RESIZE_SUCCESS;
-	error = exfat_resize_load_le32(entry, EXFAT_DIRECTORY_ENTRY_SIZE, 20, &first_cluster);
-	if (error != EXFAT_RESIZE_SUCCESS)
-		return EXFAT_RESIZE_INVALID_FILESYSTEM;
-	return first_cluster < 2 ? EXFAT_RESIZE_SUCCESS : EXFAT_RESIZE_UNSUPPORTED_ALLOCATED_ENTRY;
-}
-
 static enum exfat_resize_error scan_one_directory(struct resize_context *context,
     const struct allocation_stream *directory,
     enum directory_scan_mode mode)
@@ -1181,8 +1164,22 @@ static enum exfat_resize_error scan_one_directory(struct resize_context *context
 		case EXFAT_ENTRY_FILE:
 			error = scan_file_entry_set(context, &cursor, entry, &location, mode);
 			break;
+		case EXFAT_ENTRY_VOLUME_GUID:
+			if (!directory->root_directory || entry[EXFAT_PRIMARY_SECONDARY_COUNT_OFFSET] != 0 ||
+			    (entry[EXFAT_PRIMARY_FLAGS_OFFSET] &
+			        (EXFAT_ALLOCATION_POSSIBLE | EXFAT_NO_FAT_CHAIN)) != 0)
+				return EXFAT_RESIZE_INVALID_FILESYSTEM;
+			error = EXFAT_RESIZE_SUCCESS;
+			break;
 		default:
-			error = scan_unknown_primary(entry);
+			/*
+			 * Revision 1.00 defines no other primary directory-entry types.
+			 * Revisit this rejection before accepting later minor revisions:
+			 * future benign primaries may declare checksummed secondary entry
+			 * sets that must be consumed and preserved as a unit.
+			 */
+			error = (entry[0] & EXFAT_ENTRY_BENIGN) == 0 ? EXFAT_RESIZE_UNSUPPORTED_CRITICAL_ENTRY
+			                                             : EXFAT_RESIZE_INVALID_FILESYSTEM;
 			break;
 		}
 		if (error != EXFAT_RESIZE_SUCCESS)

--- a/tests/library/integration/resize_tests.c
+++ b/tests/library/integration/resize_tests.c
@@ -26,6 +26,7 @@ enum {
 	PERCENT_IN_USE_OFFSET = 112,
 	ENTRY_BITMAP = 0x81,
 	ENTRY_FILE = 0x85,
+	ENTRY_VOLUME_GUID = 0xa0,
 	ENTRY_STREAM = 0xc0,
 	ENTRY_FILE_NAME = 0xc1,
 	ENTRY_VENDOR_EXTENSION = 0xe0,
@@ -1304,7 +1305,7 @@ static void test_unsupported_directory_entries(void)
 		{ 0xc2, 4, 0, TARGET_SECTOR_COUNT, EXFAT_RESIZE_UNSUPPORTED_CRITICAL_ENTRY },
 		{ 0xe2, 4, 1, 12100, EXFAT_RESIZE_UNSUPPORTED_ALLOCATED_ENTRY },
 		{ 0x84, 14, 0, TARGET_SECTOR_COUNT, EXFAT_RESIZE_UNSUPPORTED_CRITICAL_ENTRY },
-		{ 0xa4, 14, 1, 12100, EXFAT_RESIZE_UNSUPPORTED_ALLOCATED_ENTRY },
+		{ 0xa4, 14, 1, 12100, EXFAT_RESIZE_INVALID_FILESYSTEM },
 	};
 	struct exfat_resize_options options = resize_options();
 	size_t index;
@@ -1324,9 +1325,11 @@ static void test_unsupported_directory_entries(void)
 		memset(entry, 0, 32);
 		entry[0] = cases[index].entry_type;
 		if (cases[index].allocated) {
-			entry[1] = ALLOCATION_POSSIBLE;
-			CHECK(
-			    exfat_resize_store_le16(entry, 32, 4, ALLOCATION_POSSIBLE) == EXFAT_RESIZE_SUCCESS);
+			if (cases[index].entry_index == 4)
+				entry[1] = ALLOCATION_POSSIBLE;
+			else
+				CHECK(exfat_resize_store_le16(entry, 32, 4, ALLOCATION_POSSIBLE) ==
+				    EXFAT_RESIZE_SUCCESS);
 			CHECK(exfat_resize_store_le32(entry, 32, 20, 5) == EXFAT_RESIZE_SUCCESS);
 			CHECK(exfat_resize_store_le64(entry, 32, 24, SECTOR_SIZE) == EXFAT_RESIZE_SUCCESS);
 		}
@@ -1487,16 +1490,19 @@ static void test_unallocated_benign_entries_are_preserved(void)
 		root_sector = exfat_fixture_cluster_sector(&fixture.geometry, 2);
 		CHECK(exfat_fixture_read_sector(&fixture, root_sector, root, sizeof(root)) == 0);
 		entry = root + 32 * 14;
-		entry[0] = secondary_case ? 0xe2 : 0xa4;
+		entry[0] = secondary_case ? 0xe2 : ENTRY_VOLUME_GUID;
 		memcpy(entry + 8, "benign-entry", 12);
-		memcpy(expected, entry, sizeof(expected));
 		if (secondary_case) {
 			unsigned char *entry_set = root + 32 * 11;
 
 			entry_set[1] = 3;
 			checksum = entry_set_checksum_count(entry_set, 4);
 			CHECK(exfat_resize_store_le16(entry_set, 32, 2, checksum) == EXFAT_RESIZE_SUCCESS);
+		} else {
+			checksum = entry_set_checksum_count(entry, 1);
+			CHECK(exfat_resize_store_le16(entry, 32, 2, checksum) == EXFAT_RESIZE_SUCCESS);
 		}
+		memcpy(expected, entry, sizeof(expected));
 		CHECK(
 		    fixture.memory.device.write(fixture.memory.device.context, root_sector, 1, root) == 0);
 		memory_block_device_clear_operations(&fixture.memory);
@@ -1509,6 +1515,46 @@ static void test_unallocated_benign_entries_are_preserved(void)
 		CHECK(exfat_fixture_read_sector(&fixture,
 		          exfat_fixture_cluster_sector(&target, mapped_root), root, sizeof(root)) == 0);
 		CHECK(memcmp(root + 32 * 14, expected, sizeof(expected)) == 0);
+		exfat_fixture_destroy(&fixture);
+	}
+}
+
+static void test_unknown_benign_primaries_are_rejected(void)
+{
+	struct exfat_resize_options options = resize_options();
+	unsigned char secondary_count;
+
+	for (secondary_count = 0; secondary_count <= 1; ++secondary_count) {
+		struct exfat_fixture fixture;
+		unsigned char root[SECTOR_SIZE];
+		unsigned char *entry_set;
+		enum exfat_resize_error error;
+		enum exfat_resize_stage stage = EXFAT_RESIZE_STAGE_COMPLETED;
+		uint16_t checksum;
+		uint64_t root_sector;
+
+		CHECK(exfat_fixture_initialize(&fixture, TARGET_SECTOR_COUNT) == 0);
+		root_sector = exfat_fixture_cluster_sector(&fixture.geometry, 2);
+		CHECK(exfat_fixture_read_sector(&fixture, root_sector, root, sizeof(root)) == 0);
+		entry_set = root + 32 * 14;
+		memset(entry_set, 0, 32 * (secondary_count + 1));
+		entry_set[0] = 0xa4;
+		entry_set[1] = secondary_count;
+		memcpy(entry_set + 8, "unknown-primary", 15);
+		if (secondary_count != 0) {
+			entry_set[32] = 0xe2;
+			memcpy(entry_set + 40, "unknown-secondary", 17);
+		}
+		checksum = entry_set_checksum_count(entry_set, secondary_count + 1);
+		CHECK(exfat_resize_store_le16(entry_set, 32, 2, checksum) == EXFAT_RESIZE_SUCCESS);
+		CHECK(
+		    fixture.memory.device.write(fixture.memory.device.context, root_sector, 1, root) == 0);
+		memory_block_device_clear_operations(&fixture.memory);
+
+		error = exfat_fixture_resize(&fixture.memory.device, TARGET_SECTOR_COUNT, &options, &stage);
+		CHECK(error == EXFAT_RESIZE_INVALID_FILESYSTEM);
+		CHECK(stage == EXFAT_RESIZE_STAGE_PREFLIGHT);
+		check_operations_are_read_only(&fixture);
 		exfat_fixture_destroy(&fixture);
 	}
 }
@@ -2652,6 +2698,7 @@ int main(void)
 	test_bitmap_entry_rejections();
 	test_malformed_bitmap_fat_chain_is_rejected();
 	test_unallocated_benign_entries_are_preserved();
+	test_unknown_benign_primaries_are_rejected();
 	test_malformed_fat_streams_are_rejected();
 	test_misplaced_system_entry_is_rejected();
 	test_truncated_entry_set_is_rejected();


### PR DESCRIPTION
Recognize revision-1.00 Volume GUID entries explicitly and reject unrecognized benign primaries during read-only preflight.

Add coverage for unknown primary sets with and without secondaries while continuing to preserve benign secondaries in recognized File entry sets.