### PR TITLE
Restrict CLI builds to macOS and Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,13 @@ project(exfat_resize VERSION ${EXFAT_RESIZE_VERSION} LANGUAGES C)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
+set(EXFAT_RESIZE_CLI_SUPPORTED OFF)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(EXFAT_RESIZE_CLI_SUPPORTED ON)
+endif()
+
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-    if(APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        set(EXFAT_RESIZE_BUILD_CLI_DEFAULT ON)
-    else()
-        set(EXFAT_RESIZE_BUILD_CLI_DEFAULT OFF)
-    endif()
+    set(EXFAT_RESIZE_BUILD_CLI_DEFAULT ${EXFAT_RESIZE_CLI_SUPPORTED})
     set(EXFAT_RESIZE_BUILD_TESTS_DEFAULT ON)
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 else()
@@ -45,6 +46,10 @@ option(
     "Build with AddressSanitizer and UndefinedBehaviorSanitizer"
     OFF
 )
+
+if(EXFAT_RESIZE_BUILD_CLI AND NOT EXFAT_RESIZE_CLI_SUPPORTED)
+    message(FATAL_ERROR "The exfat-resize CLI supports only macOS and Linux")
+endif()
 
 set(EXFAT_RESIZE_BUILD_VERSION "${PROJECT_VERSION}-unknown")
 if(EXFAT_RESIZE_BUILD_CLI)

--- a/src/device.c
+++ b/src/device.c
@@ -19,13 +19,27 @@
 #include <unistd.h>
 
 #if defined(__APPLE__)
-#include <sys/disk.h>
-#include <sys/ioctl.h>
+#include <TargetConditionals.h>
+
+#if TARGET_OS_OSX
+#define EXFAT_RESIZE_PLATFORM_MACOS 1
+#else
+#error Unsupported Apple operating system
+#endif
+
 #elif defined(__linux__)
-#include <linux/fs.h>
-#include <sys/ioctl.h>
+#define EXFAT_RESIZE_PLATFORM_LINUX 1
+
 #else
 #error Unsupported operating system
+#endif
+
+#if defined(EXFAT_RESIZE_PLATFORM_MACOS)
+#include <sys/disk.h>
+#include <sys/ioctl.h>
+#elif defined(EXFAT_RESIZE_PLATFORM_LINUX)
+#include <linux/fs.h>
+#include <sys/ioctl.h>
 #endif
 
 static int block_device_read(
@@ -57,32 +71,20 @@ static void record_io_error(struct device *device, const char *operation, int er
 	device->io_error_number = error_number;
 }
 
-int device_open_flags(int is_block_device)
-{
-	int flags = O_RDWR;
-
-#if defined(__APPLE__)
-	(void)is_block_device;
-	flags |= O_EXLOCK | O_NONBLOCK;
-#else
-	if (is_block_device)
-		flags |= O_EXCL;
-#endif
-	return flags;
-}
-
 int device_open(struct device *device, const char *path, char *error, size_t error_size)
 {
 	struct stat st;
-#if defined(__linux__)
+#if defined(EXFAT_RESIZE_PLATFORM_LINUX)
 	struct stat path_st;
 #endif
 	uint64_t bytes;
 	uint32_t sector_size = 512;
-	int flags;
+	int flags = O_RDWR;
 	int fd;
 
-#if defined(__linux__)
+#if defined(EXFAT_RESIZE_PLATFORM_MACOS)
+	flags |= O_EXLOCK | O_NONBLOCK;
+#elif defined(EXFAT_RESIZE_PLATFORM_LINUX)
 	if (stat(path, &path_st) != 0) {
 		set_error(error, error_size, path);
 		return -1;
@@ -91,9 +93,8 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 		(void)snprintf(error, error_size, "%s: not a regular file or block device", path);
 		return -1;
 	}
-	flags = device_open_flags(S_ISBLK(path_st.st_mode));
-#else
-	flags = device_open_flags(0);
+	if (S_ISBLK(path_st.st_mode))
+		flags |= O_EXCL;
 #endif
 	fd = open(path, flags);
 
@@ -109,7 +110,7 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 		set_error(error, error_size, path);
 		goto fail_after_open;
 	}
-#if defined(__linux__)
+#if defined(EXFAT_RESIZE_PLATFORM_LINUX)
 	if (st.st_dev != path_st.st_dev || st.st_ino != path_st.st_ino ||
 	    S_ISREG(st.st_mode) != S_ISREG(path_st.st_mode) ||
 	    S_ISBLK(st.st_mode) != S_ISBLK(path_st.st_mode)) {
@@ -119,7 +120,7 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 #endif
 
 	if (S_ISREG(st.st_mode)) {
-#if defined(__linux__)
+#if defined(EXFAT_RESIZE_PLATFORM_LINUX)
 		if (flock(fd, LOCK_EX | LOCK_NB) != 0) {
 			if (is_in_use_error(errno))
 				set_in_use_error(error, error_size, path);
@@ -135,7 +136,7 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 #endif
 		bytes = (uint64_t)st.st_size;
 	} else {
-#if defined(__APPLE__)
+#if defined(EXFAT_RESIZE_PLATFORM_MACOS)
 		uint64_t blocks;
 		if (ioctl(fd, DKIOCGETBLOCKSIZE, &sector_size) != 0 ||
 		    ioctl(fd, DKIOCGETBLOCKCOUNT, &blocks) != 0) {
@@ -147,7 +148,7 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 			goto fail_after_open;
 		}
 		bytes = blocks * (uint64_t)sector_size;
-#else
+#elif defined(EXFAT_RESIZE_PLATFORM_LINUX)
 		int logical_size;
 		if (ioctl(fd, BLKSSZGET, &logical_size) != 0 || logical_size <= 0 ||
 		    ioctl(fd, BLKGETSIZE64, &bytes) != 0) {
@@ -245,7 +246,7 @@ static int block_device_sync(void *context)
 	struct device *device = context;
 	int result;
 
-#if defined(__APPLE__)
+#if defined(EXFAT_RESIZE_PLATFORM_MACOS)
 	if (device->is_regular_file) {
 		do {
 			result = fcntl(device->fd, F_FULLFSYNC);
@@ -259,7 +260,7 @@ static int block_device_sync(void *context)
 			result = ioctl(device->fd, DKIOCSYNCHRONIZE, &request);
 		} while (result != 0 && errno == EINTR);
 	}
-#else
+#elif defined(EXFAT_RESIZE_PLATFORM_LINUX)
 	do {
 		result = fsync(device->fd);
 	} while (result != 0 && errno == EINTR);

--- a/src/device.h
+++ b/src/device.h
@@ -16,7 +16,6 @@ struct device {
 	struct exfat_resize_block_device block_device;
 };
 
-int device_open_flags(int is_block_device);
 int device_open(struct device *device, const char *path, char *error, size_t error_size);
 void device_close(struct device *device);
 

--- a/tests/cli/device-lock.c
+++ b/tests/cli/device-lock.c
@@ -5,7 +5,6 @@
 #include "device.h"
 
 #include <errno.h>
-#include <fcntl.h>
 #include <spawn.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -46,17 +45,6 @@ static int wait_for_child(pid_t child)
 	}
 	if (!WIFEXITED(status) || WEXITSTATUS(status) != EXIT_SUCCESS)
 		return -1;
-	return 0;
-}
-
-static int check_open_flags(void)
-{
-#if defined(__linux__)
-	if ((device_open_flags(0) & O_EXCL) != 0 || (device_open_flags(1) & O_EXCL) == 0) {
-		fprintf(stderr, "O_EXCL selection does not distinguish regular and block devices\n");
-		return -1;
-	}
-#endif
 	return 0;
 }
 
@@ -130,8 +118,6 @@ static int test_regular_file(const char *program)
 
 int main(int argc, char **argv)
 {
-	if (check_open_flags() != 0)
-		return EXIT_FAILURE;
 	if (argc == 3 && strcmp(argv[1], "--expect-locked") == 0)
 		return expect_locked_device(argv[2]);
 	if (argc == 1)

--- a/tests/package/CMakeLists.txt
+++ b/tests/package/CMakeLists.txt
@@ -27,3 +27,16 @@ add_test(
     COMMAND sh ${PROJECT_SOURCE_DIR}/tests/package/release-check.sh
 )
 set_tests_properties(package.release-check PROPERTIES LABELS package)
+
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_CROSSCOMPILING)
+    configure_file(
+        os_detection.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/os_detection.cmake
+        @ONLY
+    )
+    add_test(
+        NAME package.os-detection
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/os_detection.cmake
+    )
+    set_tests_properties(package.os-detection PROPERTIES LABELS package)
+endif()

--- a/tests/package/os_detection.cmake.in
+++ b/tests/package/os_detection.cmake.in
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+
+set(project_root "@PROJECT_SOURCE_DIR@")
+set(test_root "@CMAKE_CURRENT_BINARY_DIR@/os-detection")
+set(cmake "@CMAKE_COMMAND@")
+
+function(run_configuration build expected_cli)
+    execute_process(
+        COMMAND
+            "${cmake}"
+            -S "${project_root}"
+            -B "${build}"
+            -DEXFAT_RESIZE_BUILD_TESTS=OFF
+            ${ARGN}
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE error
+    )
+    if(NOT result EQUAL 0)
+        message(FATAL_ERROR "Configuration failed:\n${output}${error}")
+    endif()
+
+    file(
+        STRINGS "${build}/CMakeCache.txt" cli_setting
+        REGEX "^EXFAT_RESIZE_BUILD_CLI:BOOL="
+    )
+    if(NOT cli_setting STREQUAL "EXFAT_RESIZE_BUILD_CLI:BOOL=${expected_cli}")
+        message(FATAL_ERROR "Unexpected CLI setting: ${cli_setting}")
+    endif()
+endfunction()
+
+file(REMOVE_RECURSE "${test_root}")
+
+run_configuration("${test_root}/macos" ON)
+
+execute_process(
+    COMMAND xcrun --sdk iphoneos --show-sdk-path
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE ios_sdk
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT result EQUAL 0)
+    message(STATUS "iOS SDK unavailable; skipping Apple device-platform checks")
+    return()
+endif()
+
+set(ios_arguments
+    -DCMAKE_SYSTEM_NAME=iOS
+    "-DCMAKE_OSX_SYSROOT=${ios_sdk}"
+    -DCMAKE_OSX_ARCHITECTURES=arm64
+    -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
+)
+run_configuration("${test_root}/ios" OFF ${ios_arguments})
+execute_process(
+    COMMAND "${cmake}" --build "${test_root}/ios" --target exfat_resize
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error
+)
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "iOS library build failed:\n${output}${error}")
+endif()
+
+execute_process(
+    COMMAND
+        "${cmake}"
+        -S "${project_root}"
+        -B "${test_root}/ios-cli"
+        -DEXFAT_RESIZE_BUILD_TESTS=OFF
+        -DEXFAT_RESIZE_BUILD_CLI=ON
+        ${ios_arguments}
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error
+)
+if(result EQUAL 0)
+    message(FATAL_ERROR "The iOS CLI configuration unexpectedly succeeded")
+endif()
+if(NOT "${output}${error}" MATCHES "The exfat-resize CLI supports only macOS and Linux")
+    message(FATAL_ERROR "The iOS CLI configuration produced an unexpected error:\n${output}${error}")
+endif()


### PR DESCRIPTION
Default the CLI on only for supported target systems and reject explicit requests on other platforms.

Use TargetConditionals to distinguish macOS from other Apple targets, inline platform-specific device-open flags, and add iOS configuration coverage.