### PR TITLE
Stabilize untagged build identities

### DIFF
--- a/cmake/ExfatResizeVersion.cmake
+++ b/cmake/ExfatResizeVersion.cmake
@@ -25,21 +25,13 @@ function(_exfat_resize_validate_exact_tag exact_tag package_version)
     endif()
 endfunction()
 
-# Convert git describe output into the build identity shown by the CLI.
-function(_exfat_resize_format_description description package_version output_variable)
-    if(description MATCHES "^v")
-        string(SUBSTRING "${description}" 1 -1 build_version)
-    else()
-        set(build_version "${package_version}-g${description}")
-    endif()
-
-    set(${output_variable} "${build_version}" PARENT_SCOPE)
-endfunction()
-
-# Describe either the working tree or a specific commit, validating exact tags.
-function(_exfat_resize_describe_git source_dir package_version commit output_variable)
+# Resolve either the working tree or a specific commit, validating exact tags.
+function(_exfat_resize_resolve_git_build_version
+         source_dir package_version commit output_variable)
+    set(revision HEAD)
     set(commit_argument)
     if(commit)
+        set(revision "${commit}")
         list(APPEND commit_argument "${commit}")
     endif()
 
@@ -54,30 +46,44 @@ function(_exfat_resize_describe_git source_dir package_version commit output_var
     )
     if(exact_tag_result EQUAL 0)
         _exfat_resize_validate_exact_tag("${exact_tag}" "${package_version}")
+        set(build_version "${package_version}")
+    else()
+        execute_process(
+            COMMAND
+                "${GIT_EXECUTABLE}" -C "${source_dir}" rev-parse
+                --verify "${revision}^{commit}"
+            RESULT_VARIABLE object_id_result
+            OUTPUT_VARIABLE object_id
+            ERROR_VARIABLE object_id_error
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if(NOT object_id_result EQUAL 0)
+            message(FATAL_ERROR "Could not resolve Git commit: ${object_id_error}")
+        endif()
+        string(LENGTH "${object_id}" object_id_length)
+        if(NOT object_id MATCHES "^[0-9A-Fa-f]+$" OR object_id_length LESS 12)
+            message(FATAL_ERROR "Invalid Git commit object ID: '${object_id}'")
+        endif()
+        string(SUBSTRING "${object_id}" 0 12 commit_id)
+        string(TOLOWER "${commit_id}" commit_id)
+        set(build_version "${package_version}-g${commit_id}")
     endif()
 
-    set(dirty_argument)
     if(NOT commit)
-        list(APPEND dirty_argument --dirty)
-    endif()
-    execute_process(
-        COMMAND
-            "${GIT_EXECUTABLE}" -C "${source_dir}" describe
-            --tags --match "v[0-9]*" --always ${dirty_argument} ${commit_argument}
-        RESULT_VARIABLE description_result
-        OUTPUT_VARIABLE description
-        ERROR_VARIABLE description_error
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    if(NOT description_result EQUAL 0)
-        message(FATAL_ERROR "Could not describe Git source: ${description_error}")
+        execute_process(
+            COMMAND
+                "${GIT_EXECUTABLE}" -C "${source_dir}"
+                -c diff.autoRefreshIndex=true diff --quiet HEAD --
+            RESULT_VARIABLE dirty_result
+            ERROR_VARIABLE dirty_error
+        )
+        if(dirty_result EQUAL 1)
+            string(APPEND build_version "-dirty")
+        elseif(NOT dirty_result EQUAL 0)
+            message(FATAL_ERROR "Could not inspect Git checkout: ${dirty_error}")
+        endif()
     endif()
 
-    _exfat_resize_format_description(
-        "${description}"
-        "${package_version}"
-        build_version
-    )
     _exfat_resize_validate_build_version("${build_version}")
     set(${output_variable} "${build_version}" PARENT_SCOPE)
 endfunction()
@@ -110,7 +116,7 @@ function(exfat_resize_resolve_checkout_build_version
     elseif(EXISTS "${source_dir}/.git")
         find_package(Git QUIET)
         if(GIT_FOUND)
-            _exfat_resize_describe_git(
+            _exfat_resize_resolve_git_build_version(
                 "${source_dir}"
                 "${package_version}"
                 ""
@@ -148,7 +154,7 @@ function(exfat_resize_resolve_commit_version
     endif()
     _exfat_resize_validate_package_version("${package_version}")
 
-    _exfat_resize_describe_git(
+    _exfat_resize_resolve_git_build_version(
         "${source_dir}"
         "${package_version}"
         "${commit}"

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -12,8 +12,9 @@ numeric CMake package version used for compatibility checks.
 separate build identity for the CLI:
 
 1. A distribution archive supplies the identity through `.tarball-version`.
-2. A Git checkout uses `git describe`, including a `-dirty` suffix when
-   appropriate.
+2. A Git checkout at a matching `vX.Y.Z` tag uses `X.Y.Z`; otherwise it uses
+   `X.Y.Z-g<commit>`, with a fixed 12-character prefix of the full commit
+   object ID. Modified tracked files add a `-dirty` suffix.
 3. A source tree with neither form of provenance uses the package version with
    an `-unknown` suffix.
 
@@ -26,9 +27,9 @@ to determine the committed version packaged by `make dist`.
 `make dist` packages committed `HEAD`, excluding uncommitted changes, and
 writes the source archive to `dist/`. At an exact matching `vX.Y.Z` tag, the
 archive and CLI use `X.Y.Z`. Untagged archives are development snapshots whose
-`git describe` identity also depends on the repository's `v*` tag namespace.
-The archive stores that identity in `.tarball-version` and the packaged commit
-ID in Git's tar metadata.
+identity is `X.Y.Z-g<commit>`, independent of which other objects and tags are
+present in the checkout. The archive stores that identity in
+`.tarball-version` and the packaged commit ID in Git's tar metadata.
 
 ## Release procedure
 

--- a/tests/package/version.cmake
+++ b/tests/package/version.cmake
@@ -61,9 +61,9 @@ function(run_git)
     endif()
 endfunction()
 
-function(read_head output_variable)
+function(read_head source_dir output_variable)
     execute_process(
-        COMMAND "${GIT_EXECUTABLE}" -C "${repository}" rev-parse HEAD
+        COMMAND "${GIT_EXECUTABLE}" -C "${source_dir}" rev-parse HEAD
         RESULT_VARIABLE git_result
         OUTPUT_VARIABLE commit
         ERROR_VARIABLE git_error
@@ -73,6 +73,40 @@ function(read_head output_variable)
         message(FATAL_ERROR "Could not read test commit: ${git_error}")
     endif()
     set(${output_variable} "${commit}" PARENT_SCOPE)
+endfunction()
+
+function(expect_checkout source_dir expected_package_version expected_build_version)
+    exfat_resize_read_package_version("${source_dir}" package_version)
+    exfat_resize_resolve_checkout_build_version(
+        "${source_dir}"
+        "${package_version}"
+        build_version
+    )
+    if(NOT package_version STREQUAL expected_package_version OR
+       NOT build_version STREQUAL expected_build_version)
+        message(FATAL_ERROR
+            "Checkout version in ${source_dir}: expected "
+            "'${expected_package_version}' and '${expected_build_version}', got "
+            "'${package_version}' and '${build_version}'"
+        )
+    endif()
+endfunction()
+
+function(expect_commit source_dir commit expected_package_version expected_build_version)
+    exfat_resize_resolve_commit_version(
+        "${source_dir}"
+        "${commit}"
+        package_version
+        build_version
+    )
+    if(NOT package_version STREQUAL expected_package_version OR
+       NOT build_version STREQUAL expected_build_version)
+        message(FATAL_ERROR
+            "Commit version in ${source_dir}: expected "
+            "'${expected_package_version}' and '${expected_build_version}', got "
+            "'${package_version}' and '${build_version}'"
+        )
+    endif()
 endfunction()
 
 function(expect_tag_rejected mode commit)
@@ -105,7 +139,7 @@ function(expect_tag_rejected mode commit)
     string(TOLOWER "${test_output}${test_error}" test_log)
     string(FIND
         "${test_log}"
-        "tag v2.0.0 does not match package version 1.2.3"
+        "tag v2.0.0 does not match package version 1.3.0"
         mismatch_offset
     )
     if(mismatch_offset EQUAL -1)
@@ -121,43 +155,97 @@ run_git(init --quiet)
 run_git(config user.name "exfat-resize test")
 run_git(config user.email "test@example.invalid")
 file(WRITE "${repository}/VERSION" "1.2.3\n")
-run_git(add VERSION)
+file(WRITE "${repository}/NOTES" "clean\n")
+run_git(add VERSION NOTES)
 run_git(commit --quiet -m "Matching version")
-read_head(matching_commit)
+read_head("${repository}" matching_commit)
 run_git(tag v1.2.3)
 
-exfat_resize_read_package_version("${repository}" package_version)
-exfat_resize_resolve_checkout_build_version(
+expect_checkout("${repository}" "1.2.3" "1.2.3")
+expect_commit("${repository}" "${matching_commit}" "1.2.3" "1.2.3")
+
+execute_process(COMMAND "${CMAKE_COMMAND}" -E sleep 1)
+file(TOUCH_NOCREATE "${repository}/NOTES")
+expect_checkout("${repository}" "1.2.3" "1.2.3")
+
+file(APPEND "${repository}/NOTES" "dirty\n")
+expect_checkout("${repository}" "1.2.3" "1.2.3-dirty")
+expect_commit("${repository}" "${matching_commit}" "1.2.3" "1.2.3")
+run_git(checkout -- NOTES)
+
+file(WRITE "${repository}/VERSION" "1.3.0\n")
+run_git(add VERSION)
+run_git(commit --quiet -m "Version transition")
+read_head("${repository}" transition_commit)
+string(SUBSTRING "${transition_commit}" 0 12 transition_id)
+set(transition_version "1.3.0-g${transition_id}")
+
+expect_checkout("${repository}" "1.3.0" "${transition_version}")
+expect_commit(
     "${repository}"
-    "${package_version}"
-    build_version
+    "${transition_commit}"
+    "1.3.0"
+    "${transition_version}"
 )
-if(NOT package_version STREQUAL "1.2.3" OR
-   NOT build_version STREQUAL "1.2.3")
-    message(FATAL_ERROR
-        "Checkout version: expected '1.2.3', got "
-        "'${package_version}' and '${build_version}'"
-    )
+
+file(APPEND "${repository}/NOTES" "dirty\n")
+expect_checkout("${repository}" "1.3.0" "${transition_version}-dirty")
+expect_commit(
+    "${repository}"
+    "${transition_commit}"
+    "1.3.0"
+    "${transition_version}"
+)
+run_git(checkout -- NOTES)
+
+set(shallow_repository "${EXFAT_RESIZE_VERSION_TEST_DIR}/shallow-repository")
+execute_process(
+    COMMAND
+        "${GIT_EXECUTABLE}" clone --quiet --no-local --depth 1
+        "${repository}" "${shallow_repository}"
+    RESULT_VARIABLE clone_result
+    OUTPUT_VARIABLE clone_output
+    ERROR_VARIABLE clone_error
+)
+if(NOT clone_result EQUAL 0)
+    message(FATAL_ERROR "Could not create shallow clone: ${clone_output}${clone_error}")
+endif()
+if(NOT EXISTS "${shallow_repository}/.git/shallow")
+    message(FATAL_ERROR "Version test clone is not shallow")
+endif()
+read_head("${shallow_repository}" shallow_commit)
+if(NOT shallow_commit STREQUAL transition_commit)
+    message(FATAL_ERROR "Full and shallow version tests use different commits")
 endif()
 
-exfat_resize_resolve_commit_version(
-    "${repository}"
-    "${matching_commit}"
-    package_version
-    build_version
+expect_checkout("${shallow_repository}" "1.3.0" "${transition_version}")
+expect_commit(
+    "${shallow_repository}"
+    "${transition_commit}"
+    "1.3.0"
+    "${transition_version}"
 )
-if(NOT package_version STREQUAL "1.2.3" OR
-   NOT build_version STREQUAL "1.2.3")
-    message(FATAL_ERROR
-        "Commit version: expected '1.2.3', got "
-        "'${package_version}' and '${build_version}'"
-    )
-endif()
+file(APPEND "${shallow_repository}/NOTES" "dirty\n")
+expect_checkout("${shallow_repository}" "1.3.0" "${transition_version}-dirty")
+expect_commit(
+    "${shallow_repository}"
+    "${transition_commit}"
+    "1.3.0"
+    "${transition_version}"
+)
+
+run_git(tag v1.3.0 "${transition_commit}")
+expect_checkout("${repository}" "1.3.0" "1.3.0")
+expect_commit("${repository}" "${transition_commit}" "1.3.0" "1.3.0")
+file(APPEND "${repository}/NOTES" "dirty\n")
+expect_checkout("${repository}" "1.3.0" "1.3.0-dirty")
+expect_commit("${repository}" "${transition_commit}" "1.3.0" "1.3.0")
+run_git(checkout -- NOTES)
 
 file(WRITE "${repository}/change" "mismatch\n")
 run_git(add change)
 run_git(commit --quiet -m "Mismatching tag")
-read_head(mismatching_commit)
+read_head("${repository}" mismatching_commit)
 run_git(tag v2.0.0)
 
 expect_tag_rejected(checkout "${mismatching_commit}")


### PR DESCRIPTION
Base development build versions on VERSION and a fixed 12-character commit prefix instead of git describe. Keep dirty detection specific to checkout builds and ignore timestamp-only file changes.

Test full and shallow clones, tagged and untagged revisions, and dirty checkout behavior.