### PR TITLE
Add native Windows CLI, volume access, and partition growth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
           sudo apt-get update && sudo apt-get install --yes
           exfatprogs exfat-fuse gdisk qemu-utils
 
-      - name: Prepare an enlarged partition with an undersized exFAT filesystem
+      - name: Prepare an exFAT partition with trailing unallocated space
         run: sh tests/cli/prepare-windows-volume.sh build/windows-volume-fixture
 
       - name: Upload Windows logical-volume fixture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
           if (Get-Command sh.exe -ErrorAction SilentlyContinue) {
             throw "sh.exe is unexpectedly available"
           }
-          cmake -S . -B build/windows -DEXFAT_RESIZE_BUILD_CLI=ON -DEXFAT_RESIZE_BUILD_TESTS=ON
+          cmake -S . -B build/windows -DEXFAT_RESIZE_BUILD_TESTS=ON
 
       - name: Build CLI, library, and tests
         run: cmake --build build/windows --config Release --parallel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         run: mandoc -T lint build/exfat-resize.8
 
   windows:
-    name: Windows (MSVC, library)
+    name: Windows (MSVC)
     runs-on: windows-latest
 
     steps:
@@ -95,21 +95,21 @@ jobs:
 
           "PATH=$filteredPath" >> $env:GITHUB_ENV
 
-      - name: Configure library and tests without POSIX tools
+      - name: Configure CLI, library, and tests without POSIX tools
         shell: pwsh
         run: |
           if (Get-Command sh.exe -ErrorAction SilentlyContinue) {
             throw "sh.exe is unexpectedly available"
           }
-          cmake -S . -B build/windows -DEXFAT_RESIZE_BUILD_TESTS=ON
+          cmake -S . -B build/windows -DEXFAT_RESIZE_BUILD_CLI=ON -DEXFAT_RESIZE_BUILD_TESTS=ON
 
-      - name: Build library and tests
+      - name: Build CLI, library, and tests
         run: cmake --build build/windows --config Release --parallel
 
-      - name: Run library tests
+      - name: Run library and CLI tests
         run: >-
           ctest --test-dir build/windows --build-config Release
-          --output-on-failure -L library
+          --output-on-failure -L "library|cli|package-native"
 
   linux-big-endian:
     name: Linux (s390x, big endian)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,75 @@ jobs:
           ctest --test-dir build/windows --build-config Release
           --output-on-failure -L "library|cli|package-native"
 
+      - name: Upload Windows CLI for logical-volume testing
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-cli-${{ github.run_id }}
+          path: build/windows/Release/exfat-resize.exe
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  windows-volume-fixture:
+    name: Prepare Windows logical-volume fixture
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install exFAT and virtual-disk tools
+        run: >-
+          sudo apt-get update && sudo apt-get install --yes
+          exfatprogs exfat-fuse gdisk qemu-utils
+
+      - name: Prepare an enlarged partition with an undersized exFAT filesystem
+        run: sh tests/cli/prepare-windows-volume.sh build/windows-volume-fixture
+
+      - name: Upload Windows logical-volume fixture
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-volume-fixture-${{ github.run_id }}
+          path: build/windows-volume-fixture
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  windows-volume:
+    name: Windows logical volumes
+    needs:
+      - windows
+      - windows-volume-fixture
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Download Windows CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-cli-${{ github.run_id }}
+          path: build/windows-volume-program
+
+      - name: Download Windows logical-volume fixture
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-volume-fixture-${{ github.run_id }}
+          path: build/windows-volume-fixture
+
+      - name: Resize through drive-letter and volume-GUID paths
+        shell: pwsh
+        run: |
+          ./tests/cli/windows-volume.ps1 `
+            -Program build/windows-volume-program/exfat-resize.exe `
+            -Fixture build/windows-volume-fixture/prepared.vhdx `
+            -ExpectedHash build/windows-volume-fixture/payload.sha256
+
   linux-big-endian:
     name: Linux (s390x, big endian)
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ if(EXFAT_RESIZE_BUILD_CLI)
             src/windows/device.c
             src/windows/device_path.c
             src/windows/entry.c
+            src/windows/partition.c
         )
     else()
         set(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,9 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
 set(EXFAT_RESIZE_CLI_SUPPORTED OFF)
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
+   CMAKE_SYSTEM_NAME STREQUAL "Linux" OR
+   CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(EXFAT_RESIZE_CLI_SUPPORTED ON)
 endif()
 
@@ -48,7 +50,7 @@ option(
 )
 
 if(EXFAT_RESIZE_BUILD_CLI AND NOT EXFAT_RESIZE_CLI_SUPPORTED)
-    message(FATAL_ERROR "The exfat-resize CLI supports only macOS and Linux")
+    message(FATAL_ERROR "The exfat-resize CLI supports only macOS, Linux, and Windows")
 endif()
 
 set(EXFAT_RESIZE_BUILD_VERSION "${PROJECT_VERSION}-unknown")
@@ -127,10 +129,25 @@ target_include_directories(
 exfat_resize_configure_target(exfat_resize)
 
 if(EXFAT_RESIZE_BUILD_CLI)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        set(
+            EXFAT_RESIZE_CLI_SOURCES
+            src/cli.c
+            src/windows/device.c
+            src/windows/entry.c
+        )
+    else()
+        set(
+            EXFAT_RESIZE_CLI_SOURCES
+            src/cli.c
+            src/posix/device.c
+            src/posix/entry.c
+        )
+    endif()
+
     add_executable(
         exfat-resize
-        src/device.c
-        src/main.c
+        ${EXFAT_RESIZE_CLI_SOURCES}
     )
 
     target_include_directories(
@@ -154,11 +171,19 @@ if(EXFAT_RESIZE_BUILD_CLI)
 
     exfat_resize_configure_target(exfat-resize)
 
+    if(MINGW)
+        target_link_options(exfat-resize PRIVATE -municode)
+    endif()
+endif()
+
+set(EXFAT_RESIZE_INSTALL_MANPAGE OFF)
+if(EXFAT_RESIZE_BUILD_CLI AND NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
     configure_file(
         docs/exfat-resize.8.in
         ${CMAKE_CURRENT_BINARY_DIR}/exfat-resize.8
         @ONLY
     )
+    set(EXFAT_RESIZE_INSTALL_MANPAGE ON)
 endif()
 
 configure_package_config_file(
@@ -196,14 +221,16 @@ if(EXFAT_RESIZE_BUILD_CLI)
         COMPONENT
             Runtime
     )
-    install(
-        FILES
-            ${CMAKE_CURRENT_BINARY_DIR}/exfat-resize.8
-        DESTINATION
-            ${CMAKE_INSTALL_MANDIR}/man8
-        COMPONENT
-            Runtime
-    )
+    if(EXFAT_RESIZE_INSTALL_MANPAGE)
+        install(
+            FILES
+                ${CMAKE_CURRENT_BINARY_DIR}/exfat-resize.8
+            DESTINATION
+                ${CMAKE_INSTALL_MANDIR}/man8
+            COMPONENT
+                Runtime
+        )
+    endif()
 endif()
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ if(EXFAT_RESIZE_BUILD_CLI)
             EXFAT_RESIZE_CLI_SOURCES
             src/cli.c
             src/windows/device.c
+            src/windows/device_path.c
             src/windows/entry.c
         )
     else()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 exfat-resize provides a portable C11 library and command-line tool for growing
 an existing exFAT filesystem in a regular file or raw block device. On Windows,
-the initial CLI support is limited to regular image files. The backing object
+the CLI supports regular image files and logical volumes. The backing object
 must be enlarged before the filesystem is resized.
 
 ## Quick install
@@ -39,11 +39,13 @@ filesystem is unmounted and ensure the check completes successfully.
 `exfat-resize` is not a general filesystem checker; it validates only the
 invariants needed for the resize.
 
-Keep the filesystem unmounted and prevent all other access for the complete
-operation. When resizing a regular image file, also ensure it is not attached
-through a loop or disk-image device. Platform locking helps detect cooperating
-users, but regular-file locks are advisory and cannot exclude a process that
-ignores them.
+Prevent all other access for the complete operation. On macOS and Linux, keep
+the filesystem unmounted. For a Windows logical volume, close all files and
+applications using it; the CLI obtains an exclusive volume lock and dismounts
+the filesystem before accessing it. When resizing a regular image file, also
+ensure it is not attached through a loop or disk-image device. Platform locking
+helps detect cooperating users, but regular-file locks are advisory and cannot
+exclude a process that ignores them.
 
 The backing object or partition must already be enlarged. The tool does not
 enlarge regular files or partitions. A failed or interrupted resize is not
@@ -67,8 +69,8 @@ only when the command explicitly reports that it is safe.
 With no size, the filesystem grows to the available size of the backing object.
 A specified size is the desired filesystem size as an unsigned number of
 bytes. It is rounded down to a whole filesystem sector. Shrinking is not
-supported. On Windows, `device` must currently name a regular image file; drive
-letters and Windows volume or device paths are not yet accepted.
+supported. On Windows, `device` may be an image path, a drive designator such as
+`E:`, or a volume-GUID path such as `\\?\Volume{GUID}\`.
 
 Enlarge a regular file containing an exFAT filesystem, then grow the filesystem
 to use all available space:
@@ -80,6 +82,11 @@ On macOS or Linux, grow the exFAT filesystem on an unmounted raw device to use
 all available space:
 
     exfat-resize /dev/your-exfat-device
+
+On Windows, run an elevated terminal, close applications using the logical
+volume, and identify it by drive letter or volume-GUID path:
+
+    exfat-resize E:
 
 Only filesystems meeting the
 [compatibility requirements](#filesystem-compatibility) below are supported.
@@ -107,16 +114,18 @@ The core library is designed to be portable across mainstream C11 environments
 and has no operating-system dependencies. It is continuously tested with GCC
 and Clang on Linux, Apple Clang on macOS, and MSVC on Windows. The bundled CLI
 is a thin platform-specific wrapper around the library. macOS and Linux support
-regular images and raw block devices. Windows currently supports only regular
-image files; logical volumes such as `E:`, volume-GUID paths, and other Windows
-device namespaces are rejected before opening. Windows paths are accepted as
-Unicode paths.
+regular images and raw block devices. Windows supports regular images, drive
+designators such as `E:`, and volume-GUID paths. Physical disks such as
+`\\.\PhysicalDrive0` and other Windows device namespaces remain unsupported.
+Windows paths are accepted as Unicode paths.
 
 The CLI implements synchronization barriers with `F_FULLFSYNC` for regular
 images and `DKIOCSYNCHRONIZE` for raw devices on macOS, and with `fsync` on
 Linux. Windows image files are opened without sharing by using `CreateFileW`
-and synchronized with `FlushFileBuffers`. Persistence ultimately depends on the
-operating system and storage device honoring their flush requests.
+and synchronized with `FlushFileBuffers`. Windows logical volumes are opened
+for direct I/O, locked with `FSCTL_LOCK_VOLUME`, dismounted, and kept locked for
+the complete operation. Persistence ultimately depends on the operating system
+and storage device honoring their flush requests.
 On macOS, platform mechanisms reject known mounted or otherwise busy backing
 objects. The CLI retains its requested locks for the complete operation;
 regular-file locks remain advisory as described above.
@@ -237,8 +246,8 @@ For a custom installation prefix:
 
 ### Windows
 
-The Windows build includes the image-file CLI and the library by default. It
-uses only native Windows APIs and does not require a POSIX compatibility layer:
+The Windows build includes the CLI and library by default. It uses only native
+Windows APIs and does not require a POSIX compatibility layer:
 
     cmake -S . -B build
     cmake --build build --config Release
@@ -248,9 +257,16 @@ uses only native Windows APIs and does not require a POSIX compatibility layer:
 The Windows CLI accepts regular image-file paths, including Unicode paths and
 long absolute file paths. It assigns image files a 512-byte virtual sector
 size, requests exclusive file access for the complete resize, and flushes
-filesystem metadata through the Windows file API. Direct logical-volume and
-block-device access is intentionally deferred; invocations such as
-`exfat-resize E:` are not yet supported.
+filesystem metadata through the Windows file API.
+
+Logical volumes may be named by an exact drive designator such as `E:` or by an
+exact volume-GUID path such as `\\?\Volume{GUID}\`. Run the command from an
+elevated terminal and close all files and applications using the volume. The
+CLI obtains an exclusive volume lock, determines the volume's logical and
+physical sector alignment, enables access through the final sectors, dismounts
+the filesystem, and retains the lock until the operation is complete. It does
+not modify partition tables. Physical-disk paths such as
+`\\.\PhysicalDrive0` remain unsupported.
 
 ## Binary install
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,49 @@
 # exfat-resize
 
-exfat-resize provides a portable C11 library and command-line tool for growing
-an existing exFAT filesystem in a regular file or raw block device. On Windows,
-the CLI supports regular image files and logical volumes. The backing object
-must normally be enlarged before the filesystem is resized; an opt-in Windows
-mode can enlarge a supported partition as part of an explicit-size resize.
+exfat-resize provides:
 
-## Quick install
+- A portable C11 library for growing existing exFAT filesystems.
+- A command-line tool (thin wrapper around the library) for Linux, macOS,
+  and Windows.
+
+## Quick start
+
+### Prebuilt CLI binaries
+
+Prebuilt CLI binaries are provided for these platforms:
+
+- Linux x86-64 with glibc
+
+Download the prebuilt CLI from
+[GitHub Releases](https://github.com/huven/exfat-resize/releases), verify the
+SHA-256 digest shown by GitHub, then:
+
+    tar -xzf exfat-resize-X.Y.Z-linux-x86_64-glibc.tar.gz
+    cd exfat-resize-X.Y.Z-linux-x86_64-glibc
+    sudo ./install.sh
+
+See [Installing prebuilt CLI binaries](#installing-prebuilt-cli-binaries) for
+platform compatibility, checksum verification, custom installation prefixes,
+and uninstallation.
+
+### Build from source
 
 Building requires CMake 3.20 or newer and a C11 compiler.
 
     git clone https://github.com/huven/exfat-resize.git
     cd exfat-resize
-    make
-    cmake --install build
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DEXFAT_RESIZE_BUILD_TESTS=OFF
+    cmake --build build --config Release
+    cmake --install build --config Release
+
+The commands build and install both the CLI and library on Linux, macOS, and
+Windows. On other platforms, only the portable library is built by default.
 
 The install command may require elevated privileges depending on the destination
-prefix. Run `exfat-resize --help` for a usage summary. On macOS and Linux,
-`man exfat-resize` provides the complete command-line reference.
+prefix.
 
-For a prebuilt Linux CLI, see [Binary install](#binary-install).
-
-For a Windows CLI or library build, see [Windows](#windows) under Build and test.
+Before using the tool, read [Safety](#safety), then see [Usage](#usage)
+for supported targets and examples.
 
 ## Safety
 
@@ -66,15 +88,30 @@ only when the command explicitly reports that it is safe.
 ## Usage
 
     exfat-resize device [ size ]
-    exfat-resize --grow-partition windows-volume size
     exfat-resize -h | --help
     exfat-resize -V | --version
+
+Run `exfat-resize --help` for a command summary. On macOS and Linux,
+`man exfat-resize` provides the complete command-line reference.
 
 With no size, the filesystem grows to the available size of the backing object.
 A specified size is the desired filesystem size as an unsigned number of
 bytes. It is rounded down to a whole filesystem sector. Shrinking is not
-supported. On Windows, `device` may be an image path, a drive designator such as
-`E:`, or a volume-GUID path such as `\\?\Volume{GUID}\`.
+supported.
+
+The backing image, device, or partition must provide enough space for the
+requested size before the command runs. The CLI never enlarges an image file.
+On Windows, [`--grow-partition`](#growing-the-containing-partition) can
+optionally enlarge a supported partition as part of an explicit-size resize.
+
+Only filesystems meeting the
+[compatibility requirements](#filesystem-compatibility) below are supported.
+
+### macOS and Linux
+
+`device` may be a regular image file or an unmounted raw block device. Prevent
+all other access to it for the complete operation. In particular, do not leave
+an image attached through a loop or disk-image device while resizing it.
 
 Enlarge a regular file containing an exFAT filesystem, then grow the filesystem
 to use all available space:
@@ -82,33 +119,76 @@ to use all available space:
     truncate -s +2G image.exfat
     exfat-resize image.exfat
 
-On macOS or Linux, grow the exFAT filesystem on an unmounted raw device to use
-all available space:
+After enlarging the partition or other backing storage with the appropriate
+platform tool, grow the filesystem on an unmounted raw device:
 
     exfat-resize /dev/your-exfat-device
 
-On Windows, run an elevated terminal, close applications using the logical
-volume, and identify it by drive letter or volume-GUID path:
+Regular-file locks are advisory and cannot exclude a process that ignores them.
+On macOS, the CLI rejects known mounted or otherwise busy backing objects. Keep
+the image or raw device unavailable to other processes until the command has
+finished.
+
+### Windows
+
+`device` may be:
+
+- A regular image-file path, including a Unicode path.
+- An exact drive designator such as `E:`.
+- An exact volume-GUID path such as `\\?\Volume{GUID}\`.
+
+Physical-disk paths such as `\\.\PhysicalDrive0` and other Windows device
+namespace forms are not supported as command targets.
+
+An image file must already have the desired length and is presented to the
+filesystem as a device with 512-byte sectors. Resizing an image normally does
+not require Administrator privileges, although the account running the command
+must have exclusive read/write access to the file:
+
+    exfat-resize C:\path\to\image.exfat
+
+For a logical volume, open an elevated terminal and close all files and
+applications using it. The CLI locks the volume exclusively before reading or
+writing it, retains the lock for the complete operation, synchronizes all
+writes, and dismounts the filesystem before releasing the lock. If the volume
+cannot be locked, the resize does not start.
+
+Use either its drive designator or volume-GUID path:
 
     exfat-resize E:
+    exfat-resize \\?\Volume{GUID}\
 
-### Growing a Windows partition
+These commands grow the filesystem to the existing volume size; they do not
+change its partition table. An explicit size may also be supplied when it fits
+inside the existing volume:
 
-For a logical Windows volume, `--grow-partition` asks the CLI to enlarge its
-partition when the explicit filesystem size does not currently fit. For
-example, this requests a 512 GiB partition and filesystem:
+    exfat-resize E: 549755813888
+
+#### Growing the containing partition
+
+If an explicit size does not fit inside a logical Windows volume,
+`--grow-partition` asks the CLI to enlarge the containing partition first:
 
     exfat-resize --grow-partition E: 549755813888
 
-This mode is deliberately opt-in: changing a partition table has a wider
-effect than changing metadata within the selected filesystem. It requires an
-elevated terminal, an explicit size, a single-disk-extent basic GPT or MBR data
-partition with no overlapping layout entry, and enough immediately trailing
-unallocated space. The CLI checks the volume-to-disk mapping and current
-physical partition layout before using Windows' documented
-[`IOCTL_DISK_GROW_PARTITION`][windows-grow-partition]. It never moves the
-partition start or another partition, and never shrinks a partition. It
-validates both exFAT boot regions before requesting the change.
+This example requests a 512 GiB volume and grows the filesystem to use it. If
+the requested size already fits, the partition table is left unchanged and the
+filesystem resize proceeds normally.
+
+Partition growth is deliberately opt-in because changing a partition table has
+a wider effect than changing metadata within the selected filesystem. It
+requires:
+
+- An elevated terminal and an explicit size.
+- A logical volume that maps to one complete physical-disk extent.
+- A basic GPT or MBR data partition with no overlapping layout entry.
+- Enough unallocated space immediately after the partition.
+
+Before changing the partition table, the CLI validates both exFAT boot regions,
+checks that the filesystem can grow to the requested size, and verifies the
+volume-to-disk mapping and physical partition layout. It then uses Windows'
+documented [`IOCTL_DISK_GROW_PARTITION`][windows-grow-partition]. It never moves
+a partition start or another partition, and never shrinks a partition.
 
 The full filesystem preflight runs after the partition is enlarged. If that
 preflight fails, the original filesystem remains authoritative inside the
@@ -116,9 +196,9 @@ larger partition; do not shrink the partition. Correct the reported problem
 and retry the filesystem resize. Without `--grow-partition`, the CLI never
 changes a partition table.
 
-As a fallback for layouts this initial implementation does not support, boot
-[GParted Live][gparted-live], identify the whole target disk carefully, and use
-the included terminal rather than GParted's graphical exFAT resize action:
+For a layout that this mode does not support, one open-source alternative is to
+boot [GParted Live][gparted-live], identify the whole target disk carefully, and
+use the included terminal rather than GParted's graphical exFAT resize action:
 
 ```text
 sudo parted /dev/sdX
@@ -143,9 +223,6 @@ will silently extend only an exFAT partition.
 [resizepart]: https://www.gnu.org/software/parted/manual/html_node/resizepart.html
 [windows-grow-partition]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntdddisk/ni-ntdddisk-ioctl_disk_grow_partition
 
-Only filesystems meeting the
-[compatibility requirements](#filesystem-compatibility) below are supported.
-
 ## Filesystem compatibility
 
 The filesystem must meet these prerequisites:
@@ -168,23 +245,27 @@ The filesystem must meet these prerequisites:
 The core library is designed to be portable across mainstream C11 environments
 and has no operating-system dependencies. It is continuously tested with GCC
 and Clang on Linux, Apple Clang on macOS, and MSVC on Windows. The bundled CLI
-is a thin platform-specific wrapper around the library. macOS and Linux support
-regular images and raw block devices. Windows supports regular images, drive
-designators such as `E:`, and volume-GUID paths. Physical-disk paths such as
-`\\.\PhysicalDrive0`, and device-namespace paths other than those accepted
-volume forms, remain unsupported. Windows paths are accepted as Unicode paths.
+is a thin platform-specific wrapper around the library.
+
+| Platform | Image files | Direct filesystem access | Partition growth |
+| --- | --- | --- | --- |
+| macOS | Yes | Raw block devices | Use an external partitioning tool |
+| Linux | Yes | Raw block devices | Use an external partitioning tool |
+| Windows | Yes | Drive designators and volume-GUID paths | `--grow-partition` for supported layouts |
 
 The CLI implements synchronization barriers with `F_FULLFSYNC` for regular
 images and `DKIOCSYNCHRONIZE` for raw devices on macOS, and with `fsync` on
 Linux. Windows image files are opened without sharing by using `CreateFileW`
-and synchronized with `FlushFileBuffers`. Windows logical volumes are opened
-for direct I/O, locked with `FSCTL_LOCK_VOLUME`, and kept locked for the complete
-operation. After the final synchronization barrier, the CLI dismounts the
-volume before releasing the lock. Persistence ultimately depends on the
-operating system and storage device honoring their flush requests.
+and synchronized with `FlushFileBuffers`. The Windows volume backend discovers
+the logical and physical sector alignment, enables access through the final
+volume sectors, and uses aligned direct I/O. Logical volumes are locked with
+`FSCTL_LOCK_VOLUME` and kept locked for the complete operation. After the final
+synchronization barrier, the CLI dismounts the volume before releasing the
+lock. Persistence ultimately depends on the operating system and storage device
+honoring their flush requests.
 On macOS, platform mechanisms reject known mounted or otherwise busy backing
-objects. The CLI retains its requested locks for the complete operation;
-regular-file locks remain advisory as described above.
+objects. On every platform, the CLI retains its requested locks for the
+complete operation; regular-file locks remain advisory as described above.
 
 ## C library
 
@@ -271,62 +352,9 @@ between separately compiled artifacts from different releases or deliberately
 different compiler ABIs is not promised. Incompatible source changes require a
 new major release.
 
-## Build and test
+## Installing prebuilt CLI binaries
 
-CMake 3.20 or newer is the canonical build system for the library, CLI, and
-tests. The top-level Makefile is a convenience wrapper around CMake and the
-release scripts. If the macOS CMake application is installed without
-command-line links, add its tools to `PATH`:
-
-    export PATH=/Applications/CMake.app/Contents/bin:$PATH
-
-    make
-    make test
-    make sanitize-test
-    make release-test
-
-`make` produces `build/exfat-resize`. `make test` builds every target and runs
-the separately labeled library, package, and CLI suites through CTest. The CLI
-tests use newfs_exfat and fsck_exfat on macOS, or mkfs.exfat and fsck.exfat on
-Linux. The sanitizer target runs all suites with AddressSanitizer and
-UndefinedBehaviorSanitizer in a separate build directory. It also builds and
-runs C and C++ `add_subdirectory()` consumers to verify the sanitized static
-library's runtime link requirements.
-The release target creates and verifies the source archive from committed
-`HEAD`, installs it into a temporary prefix, and builds C and C++ consumers
-using both `find_package()` and `add_subdirectory()`.
-
-For a custom installation prefix:
-
-    cmake --install build --prefix /your/prefix
-
-### Windows
-
-The Windows build includes the CLI and library by default. It uses only native
-Windows APIs and does not require a POSIX compatibility layer:
-
-    cmake -S . -B build
-    cmake --build build --config Release
-    ctest --test-dir build --build-config Release --output-on-failure -L "library|cli|package-native"
-    cmake --install build --config Release
-
-The Windows CLI accepts regular image-file paths, including Unicode paths and
-long absolute file paths. It assigns image files a 512-byte virtual sector
-size, requests exclusive file access for the complete resize, and flushes
-filesystem metadata through the Windows file API.
-
-Logical volumes may be named by an exact drive designator such as `E:` or by an
-exact volume-GUID path such as `\\?\Volume{GUID}\`. Run the command from an
-elevated terminal and close all files and applications using the volume. The
-CLI obtains an exclusive volume lock, determines the volume's logical and
-physical sector alignment, enables access through the final sectors, and
-retains the lock until all writes have been synchronized. It then dismounts the
-filesystem before releasing the lock. With an explicit size and
-`--grow-partition`, it can map a simple volume to its physical disk and request
-that Windows enlarge the containing basic partition first. Physical-disk paths
-such as `\\.\PhysicalDrive0` remain unsupported as command targets.
-
-## Binary install
+### Linux
 
 GitHub Releases provide a prebuilt CLI archive expected to run on all conventional
 `x86_64` Linux distributions using glibc 2.28 or newer. It is built on
@@ -360,3 +388,46 @@ installed files:
 For a custom prefix, remove it with:
 
     PREFIX=/your/prefix ./uninstall.sh
+
+## Build and test
+
+CMake 3.20 or newer is the canonical build system for the library, CLI, and
+tests.
+
+### macOS and Linux
+
+The top-level Makefile is a convenience wrapper around CMake and the release
+scripts. If the macOS CMake application is installed without command-line
+links, add its tools to `PATH`:
+
+    export PATH=/Applications/CMake.app/Contents/bin:$PATH
+
+    make
+    make test
+    make sanitize-test
+    make release-test
+
+`make` produces `build/exfat-resize`. `make test` builds every target and runs
+the separately labeled library, package, and CLI suites through CTest. The CLI
+tests use newfs_exfat and fsck_exfat on macOS, or mkfs.exfat and fsck.exfat on
+Linux. The sanitizer target runs all suites with AddressSanitizer and
+UndefinedBehaviorSanitizer in a separate build directory. It also builds and
+runs C and C++ `add_subdirectory()` consumers to verify the sanitized static
+library's runtime link requirements.
+The release target creates and verifies the source archive from committed
+`HEAD`, installs it into a temporary prefix, and builds C and C++ consumers
+using both `find_package()` and `add_subdirectory()`.
+
+For a custom installation prefix:
+
+    cmake --install build --prefix /your/prefix
+
+### Windows build
+
+The Windows build includes the CLI and library by default. It uses only native
+Windows APIs and does not require a POSIX compatibility layer:
+
+    cmake -S . -B build
+    cmake --build build --config Release
+    ctest --test-dir build --build-config Release --output-on-failure -L "library|cli|package-native"
+    cmake --install build --config Release

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 exfat-resize provides a portable C11 library and command-line tool for growing
 an existing exFAT filesystem in a regular file or raw block device. On Windows,
 the CLI supports regular image files and logical volumes. The backing object
-must be enlarged before the filesystem is resized.
+must normally be enlarged before the filesystem is resized; an opt-in Windows
+mode can enlarge a supported partition as part of an explicit-size resize.
 
 ## Quick install
 
@@ -31,8 +32,8 @@ For a Windows CLI or library build, see [Windows](#windows) under Build and test
 
 Verify that the supplied path resolves to the intended filesystem. Paths may
 resolve through symbolic links, and the selected device must present the exFAT
-main boot sector at sector zero; the tool does not inspect or modify partition
-tables.
+main boot sector at sector zero. The CLI does not modify partition tables unless
+the Windows-only `--grow-partition` option is explicitly supplied.
 
 Before resizing, run an appropriate exFAT filesystem checker while the
 filesystem is unmounted and ensure the check completes successfully.
@@ -48,11 +49,12 @@ a loop or disk-image device. Platform locking helps detect cooperating users,
 but regular-file locks are advisory and cannot exclude a process that ignores
 them.
 
-The backing object or partition must already be enlarged. The tool does not
-enlarge regular files or partitions. A failed or interrupted resize is not
-automatically repaired, rolled back, or resumable. Follow the recovery guidance
-printed with an error; depending on the stage reached, recovery may require a
-filesystem checker or restoring the verified backup.
+The backing object or partition must already be enlarged unless a supported
+Windows logical volume is used with `--grow-partition`. The tool never enlarges
+regular files. A failed or interrupted resize is not automatically repaired,
+rolled back, or resumable. Follow the recovery guidance printed with an error;
+depending on the stage reached, recovery may require a filesystem checker or
+restoring the verified backup.
 
 Every normal error exit prints stage-specific recovery guidance. If the command
 terminates abnormally without printing stage-specific recovery guidance, for
@@ -64,6 +66,7 @@ only when the command explicitly reports that it is safe.
 ## Usage
 
     exfat-resize device [ size ]
+    exfat-resize --grow-partition windows-volume size
     exfat-resize -h | --help
     exfat-resize -V | --version
 
@@ -88,6 +91,56 @@ On Windows, run an elevated terminal, close applications using the logical
 volume, and identify it by drive letter or volume-GUID path:
 
     exfat-resize E:
+
+### Growing a Windows partition
+
+For a logical Windows volume, `--grow-partition` asks the CLI to enlarge its
+partition when the explicit filesystem size does not currently fit. For
+example, this requests a 512 GiB partition and filesystem:
+
+    exfat-resize --grow-partition E: 549755813888
+
+This mode is deliberately opt-in: changing a partition table has a wider
+effect than changing metadata within the selected filesystem. It requires an
+elevated terminal, an explicit size, a single-disk-extent basic GPT or MBR data
+partition, and enough immediately trailing unallocated space. The CLI checks
+the volume-to-disk mapping and current physical partition layout before using
+Windows' documented [`IOCTL_DISK_GROW_PARTITION`][windows-grow-partition]. It
+never moves the partition start or another partition, and never shrinks a
+partition. It validates both exFAT boot regions before requesting the change.
+
+The full filesystem preflight runs after the partition is enlarged. If that
+preflight fails, the original filesystem remains authoritative inside the
+larger partition; do not shrink the partition. Correct the reported problem
+and retry the filesystem resize. Without `--grow-partition`, the CLI never
+changes a partition table.
+
+As a fallback for layouts this initial implementation does not support, boot
+[GParted Live][gparted-live], identify the whole target disk carefully, and use
+the included terminal rather than GParted's graphical exFAT resize action:
+
+```text
+sudo parted /dev/sdX
+(parted) unit s
+(parted) print free
+(parted) resizepart PARTITION_NUMBER NEW_END_SECTOR
+(parted) quit
+```
+
+[GNU Parted documents][resizepart] that `resizepart` changes the partition end
+without modifying the filesystem. Record the start sector first, select only
+an end sector in the immediately following free extent, and verify afterwards
+that the start is unchanged. Do not use this procedure to shrink exFAT.
+
+Windows DiskPart is not a substitute: its [documented `extend`
+operation][diskpart-extend] automatically extends NTFS and fails without a
+partition change for other formatted filesystems. Do not rely on claims that it
+will silently extend only an exFAT partition.
+
+[diskpart-extend]: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/extend
+[gparted-live]: https://gparted.org/livecd.php
+[resizepart]: https://www.gnu.org/software/parted/manual/html_node/resizepart.html
+[windows-grow-partition]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntdddisk/ni-ntdddisk-ioctl_disk_grow_partition
 
 Only filesystems meeting the
 [compatibility requirements](#filesystem-compatibility) below are supported.
@@ -267,9 +320,10 @@ elevated terminal and close all files and applications using the volume. The
 CLI obtains an exclusive volume lock, determines the volume's logical and
 physical sector alignment, enables access through the final sectors, and
 retains the lock until all writes have been synchronized. It then dismounts the
-filesystem before releasing the lock. It does not modify partition tables.
-Physical-disk paths such as
-`\\.\PhysicalDrive0` remain unsupported.
+filesystem before releasing the lock. With an explicit size and
+`--grow-partition`, it can map a simple volume to its physical disk and request
+that Windows enlarge the containing basic partition first. Physical-disk paths
+such as `\\.\PhysicalDrive0` remain unsupported as command targets.
 
 ## Binary install
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,12 @@ example, this requests a 512 GiB partition and filesystem:
 This mode is deliberately opt-in: changing a partition table has a wider
 effect than changing metadata within the selected filesystem. It requires an
 elevated terminal, an explicit size, a single-disk-extent basic GPT or MBR data
-partition, and enough immediately trailing unallocated space. The CLI checks
-the volume-to-disk mapping and current physical partition layout before using
-Windows' documented [`IOCTL_DISK_GROW_PARTITION`][windows-grow-partition]. It
-never moves the partition start or another partition, and never shrinks a
-partition. It validates both exFAT boot regions before requesting the change.
+partition with no overlapping layout entry, and enough immediately trailing
+unallocated space. The CLI checks the volume-to-disk mapping and current
+physical partition layout before using Windows' documented
+[`IOCTL_DISK_GROW_PARTITION`][windows-grow-partition]. It never moves the
+partition start or another partition, and never shrinks a partition. It
+validates both exFAT boot regions before requesting the change.
 
 The full filesystem preflight runs after the partition is enlarged. If that
 preflight fails, the original filesystem remains authoritative inside the
@@ -169,9 +170,9 @@ and has no operating-system dependencies. It is continuously tested with GCC
 and Clang on Linux, Apple Clang on macOS, and MSVC on Windows. The bundled CLI
 is a thin platform-specific wrapper around the library. macOS and Linux support
 regular images and raw block devices. Windows supports regular images, drive
-designators such as `E:`, and volume-GUID paths. Physical disks such as
-`\\.\PhysicalDrive0` and other Windows device namespaces remain unsupported.
-Windows paths are accepted as Unicode paths.
+designators such as `E:`, and volume-GUID paths. Physical-disk paths such as
+`\\.\PhysicalDrive0`, and device-namespace paths other than those accepted
+volume forms, remain unsupported. Windows paths are accepted as Unicode paths.
 
 The CLI implements synchronization barriers with `F_FULLFSYNC` for regular
 images and `DKIOCSYNCHRONIZE` for raw devices on macOS, and with `fsync` on

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ invariants needed for the resize.
 
 Prevent all other access for the complete operation. On macOS and Linux, keep
 the filesystem unmounted. For a Windows logical volume, close all files and
-applications using it; the CLI obtains an exclusive volume lock and dismounts
-the filesystem before accessing it. When resizing a regular image file, also
-ensure it is not attached through a loop or disk-image device. Platform locking
-helps detect cooperating users, but regular-file locks are advisory and cannot
-exclude a process that ignores them.
+applications using it; the CLI obtains an exclusive volume lock, retains it
+while accessing the volume, and dismounts the filesystem before releasing the
+lock. When resizing a regular image file, also ensure it is not attached through
+a loop or disk-image device. Platform locking helps detect cooperating users,
+but regular-file locks are advisory and cannot exclude a process that ignores
+them.
 
 The backing object or partition must already be enlarged. The tool does not
 enlarge regular files or partitions. A failed or interrupted resize is not
@@ -123,9 +124,10 @@ The CLI implements synchronization barriers with `F_FULLFSYNC` for regular
 images and `DKIOCSYNCHRONIZE` for raw devices on macOS, and with `fsync` on
 Linux. Windows image files are opened without sharing by using `CreateFileW`
 and synchronized with `FlushFileBuffers`. Windows logical volumes are opened
-for direct I/O, locked with `FSCTL_LOCK_VOLUME`, dismounted, and kept locked for
-the complete operation. Persistence ultimately depends on the operating system
-and storage device honoring their flush requests.
+for direct I/O, locked with `FSCTL_LOCK_VOLUME`, and kept locked for the complete
+operation. After the final synchronization barrier, the CLI dismounts the
+volume before releasing the lock. Persistence ultimately depends on the
+operating system and storage device honoring their flush requests.
 On macOS, platform mechanisms reject known mounted or otherwise busy backing
 objects. The CLI retains its requested locks for the complete operation;
 regular-file locks remain advisory as described above.
@@ -263,9 +265,10 @@ Logical volumes may be named by an exact drive designator such as `E:` or by an
 exact volume-GUID path such as `\\?\Volume{GUID}\`. Run the command from an
 elevated terminal and close all files and applications using the volume. The
 CLI obtains an exclusive volume lock, determines the volume's logical and
-physical sector alignment, enables access through the final sectors, dismounts
-the filesystem, and retains the lock until the operation is complete. It does
-not modify partition tables. Physical-disk paths such as
+physical sector alignment, enables access through the final sectors, and
+retains the lock until all writes have been synchronized. It then dismounts the
+filesystem before releasing the lock. It does not modify partition tables.
+Physical-disk paths such as
 `\\.\PhysicalDrive0` remain unsupported.
 
 ## Binary install

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # exfat-resize
 
 exfat-resize provides a portable C11 library and command-line tool for growing
-an existing exFAT filesystem in a regular file or raw block device. The backing
-object must be enlarged before the filesystem is resized.
+an existing exFAT filesystem in a regular file or raw block device. On Windows,
+the initial CLI support is limited to regular image files. The backing object
+must be enlarged before the filesystem is resized.
 
 ## Quick install
 
@@ -14,12 +15,12 @@ Building requires CMake 3.20 or newer and a C11 compiler.
     cmake --install build
 
 The install command may require elevated privileges depending on the destination
-prefix. Run `exfat-resize --help` for a usage summary or `man exfat-resize` for
-the complete command-line reference.
+prefix. Run `exfat-resize --help` for a usage summary. On macOS and Linux,
+`man exfat-resize` provides the complete command-line reference.
 
 For a prebuilt Linux CLI, see [Binary install](#binary-install).
 
-For a Windows library build, see [Windows](#windows) under Build and test.
+For a Windows CLI or library build, see [Windows](#windows) under Build and test.
 
 ## Safety
 
@@ -66,7 +67,8 @@ only when the command explicitly reports that it is safe.
 With no size, the filesystem grows to the available size of the backing object.
 A specified size is the desired filesystem size as an unsigned number of
 bytes. It is rounded down to a whole filesystem sector. Shrinking is not
-supported.
+supported. On Windows, `device` must currently name a regular image file; drive
+letters and Windows volume or device paths are not yet accepted.
 
 Enlarge a regular file containing an exFAT filesystem, then grow the filesystem
 to use all available space:
@@ -74,7 +76,8 @@ to use all available space:
     truncate -s +2G image.exfat
     exfat-resize image.exfat
 
-Grow the exFAT filesystem on an unmounted raw device to use all available space:
+On macOS or Linux, grow the exFAT filesystem on an unmounted raw device to use
+all available space:
 
     exfat-resize /dev/your-exfat-device
 
@@ -103,15 +106,17 @@ The filesystem must meet these prerequisites:
 The core library is designed to be portable across mainstream C11 environments
 and has no operating-system dependencies. It is continuously tested with GCC
 and Clang on Linux, Apple Clang on macOS, and MSVC on Windows. The bundled CLI
-is a thin platform-specific wrapper around the library and is currently
-supported and tested on macOS and Linux. Porting the CLI primarily requires
-implementing device access, exclusive-access checks, and durable
-synchronization for the target platform; contributions are welcome.
+is a thin platform-specific wrapper around the library. macOS and Linux support
+regular images and raw block devices. Windows currently supports only regular
+image files; logical volumes such as `E:`, volume-GUID paths, and other Windows
+device namespaces are rejected before opening. Windows paths are accepted as
+Unicode paths.
 
 The CLI implements synchronization barriers with `F_FULLFSYNC` for regular
 images and `DKIOCSYNCHRONIZE` for raw devices on macOS, and with `fsync` on
-Linux. Persistence ultimately depends on the operating system and storage
-device honoring their flush requests.
+Linux. Windows image files are opened without sharing by using `CreateFileW`
+and synchronized with `FlushFileBuffers`. Persistence ultimately depends on the
+operating system and storage device honoring their flush requests.
 On macOS, platform mechanisms reject known mounted or otherwise busy backing
 objects. The CLI retains its requested locks for the complete operation;
 regular-file locks remain advisory as described above.
@@ -186,8 +191,8 @@ failure guarantees.
 
 Downstream CMake projects can use `add_subdirectory()` and link
 `exfat_resize::exfat_resize`. The install target also provides the header,
-static library, CLI executable, manual page, and CMake package files. This
-README and the exact MIT license are installed under CMake's
+static library, CLI executable, CMake package files, and a manual page on macOS
+and Linux. This README and the exact MIT license are installed under CMake's
 `CMAKE_INSTALL_DOCDIR`.
 Installed CMake packages use same-major version compatibility, so consumers
 can require a compatible 1.x release:
@@ -232,13 +237,20 @@ For a custom installation prefix:
 
 ### Windows
 
-The CLI is not currently supported on Windows, so a standalone CMake build
-includes only the library and its tests by default:
+The Windows build includes the image-file CLI and the library by default. It
+uses only native Windows APIs and does not require a POSIX compatibility layer:
 
     cmake -S . -B build
     cmake --build build --config Release
-    ctest --test-dir build --build-config Release --output-on-failure -L library
+    ctest --test-dir build --build-config Release --output-on-failure -L "library|cli|package-native"
     cmake --install build --config Release
+
+The Windows CLI accepts regular image-file paths, including Unicode paths and
+long absolute file paths. It assigns image files a 512-byte virtual sector
+size, requests exclusive file access for the complete resize, and flushes
+filesystem metadata through the Windows file API. Direct logical-volume and
+block-device access is intentionally deferred; invocations such as
+`exfat-resize E:` are not yet supported.
 
 ## Binary install
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -15,13 +15,16 @@
 #endif
 
 #if defined(_WIN32)
-static const char target_name[] = "IMAGE";
-static const char introduction[] = "Grow an existing exFAT filesystem in a Windows image file.";
-static const char target_description[] = "Regular image file with the exFAT main boot sector\n"
-                                         "                     at sector zero";
+static const char target_name[] = "DEVICE";
+static const char introduction[] =
+    "Grow an existing exFAT filesystem in a Windows image file or logical volume.";
+static const char target_description[] =
+    "Regular image file, drive letter such as E:, or\n"
+    "                     volume-GUID path with the exFAT main boot sector\n"
+    "                     at sector zero";
 static const char documentation_lead[] = "";
 static const char platform_note[] =
-    "\nWindows volumes such as E: and volume-GUID paths are not supported yet.\n";
+    "\nPhysical-disk paths such as \\\\.\\PhysicalDrive0 are not supported.\n";
 #else
 static const char target_name[] = "DEVICE";
 static const char introduction[] = "Grow an existing exFAT filesystem.";

--- a/src/cli.c
+++ b/src/cli.c
@@ -273,8 +273,17 @@ int cli_main(int argc, char **argv)
 		case EXFAT_RESIZE_STAGE_COMPLETED:
 			break;
 		}
+	}
+	if (device_dismount(&device, positional[0], error, sizeof(error)) != 0) {
+		fprintf(stderr, "exfat-resize: %s\n", error);
+		if (result == EXFAT_RESIZE_SUCCESS)
+			fprintf(stderr,
+			    "exfat-resize: the resize completed and was synchronized; remount the "
+			    "volume and run a filesystem checker; do not retry the resize\n");
 		goto out;
 	}
+	if (result != EXFAT_RESIZE_SUCCESS)
+		goto out;
 	printf("exfat-resize: resized %s\n", positional[0]);
 	status = EXIT_SUCCESS;
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -178,13 +178,16 @@ static int parse_size(const char *text, uint64_t *value)
 	return 0;
 }
 
-static enum exfat_resize_error validate_source_boot_regions(
-    const struct exfat_resize_block_device *device)
+static enum exfat_resize_error validate_partition_growth_preflight(
+    const struct exfat_resize_block_device *device, uint64_t target_size)
 {
+	struct exfat_resize_device_geometry target_device_geometry;
 	struct exfat_resize_sector_adapter adapter;
+	struct exfat_resize_geometry target_geometry;
 	struct exfat_resize_geometry geometry;
 	enum exfat_resize_error result;
 	unsigned char *buffer;
+	uint64_t target_sector_count;
 	uint32_t filesystem_sector_size;
 
 	buffer = malloc(EXFAT_RESIZE_MAX_SECTOR_SIZE);
@@ -199,8 +202,41 @@ static enum exfat_resize_error validate_source_boot_regions(
 	if (result == EXFAT_RESIZE_SUCCESS)
 		result = exfat_resize_read_boot_regions(
 		    &adapter.device, buffer, EXFAT_RESIZE_MAX_SECTOR_SIZE, &geometry);
+	if (result == EXFAT_RESIZE_SUCCESS) {
+		target_sector_count = target_size / filesystem_sector_size;
+		if (target_sector_count <= geometry.volume_sector_count) {
+			result = EXFAT_RESIZE_INSUFFICIENT_GROWTH;
+		} else {
+			target_device_geometry.logical_sector_size = filesystem_sector_size;
+			target_device_geometry.sector_count = target_sector_count;
+			result = exfat_resize_plan_growth(
+			    &target_device_geometry, &geometry, target_sector_count, &target_geometry);
+		}
+	}
 	free(buffer);
 	return result;
+}
+
+static const char *device_error_separator(const char *path)
+{
+#if defined(_WIN32)
+	size_t length = strlen(path);
+
+	if (length != 0 && path[length - 1] == ':')
+		return " ";
+#else
+	(void)path;
+#endif
+	return ": ";
+}
+
+static void print_device_io_error(const struct device *device, const char *path)
+{
+	char error[256];
+
+	device_format_io_error(device, error, sizeof(error));
+	fprintf(stderr, "exfat-resize: %s %s%s%s\n", device->io_error_operation, path,
+	    device_error_separator(path), error);
 }
 
 static void print_partition_grown_guidance(void)
@@ -219,7 +255,6 @@ int cli_main(int argc, char **argv)
 	const char *positional[2];
 	uint64_t target = 0;
 	char error[512];
-	char io_error[256];
 	int positional_count = 0;
 	int parse_options = 1;
 	int grow_partition = 0;
@@ -315,19 +350,15 @@ int cli_main(int argc, char **argv)
 		if (target > current_size) {
 			/*
 			 * The library's complete preflight needs the requested target to fit the
-			 * device. Validate the source boot regions before changing that device's
-			 * partition, then let the normal resize perform the full preflight.
+			 * device. Validate the source boot regions and target geometry before
+			 * changing that device's partition, then run the complete preflight.
 			 */
-			result = validate_source_boot_regions(&device.block_device);
+			result = validate_partition_growth_preflight(&device.block_device, target);
 			if (result != EXFAT_RESIZE_SUCCESS) {
-				fprintf(stderr,
-				    "exfat-resize: cannot grow partition: source validation failed: %s\n",
+				fprintf(stderr, "exfat-resize: cannot grow partition: preflight failed: %s\n",
 				    resize_error(result));
-				if (result == EXFAT_RESIZE_IO_ERROR && device.io_error_operation != NULL) {
-					device_format_io_error(&device, io_error, sizeof(io_error));
-					fprintf(stderr, "exfat-resize: %s %s: %s\n", device.io_error_operation,
-					    positional[0], io_error);
-				}
+				if (result == EXFAT_RESIZE_IO_ERROR && device.io_error_operation != NULL)
+					print_device_io_error(&device, positional[0]);
 				print_no_write_guidance();
 				goto out;
 			}
@@ -354,11 +385,8 @@ int cli_main(int argc, char **argv)
 	result = exfat_resize(&device.block_device, target, &options, &stage);
 	if (result != EXFAT_RESIZE_SUCCESS) {
 		fprintf(stderr, "exfat-resize: resize failed: %s\n", resize_error(result));
-		if (result == EXFAT_RESIZE_IO_ERROR && device.io_error_operation != NULL) {
-			device_format_io_error(&device, io_error, sizeof(io_error));
-			fprintf(stderr, "exfat-resize: %s %s: %s\n", device.io_error_operation, positional[0],
-			    io_error);
-		}
+		if (result == EXFAT_RESIZE_IO_ERROR && device.io_error_operation != NULL)
+			print_device_io_error(&device, positional[0]);
 		switch (stage) {
 		case EXFAT_RESIZE_STAGE_PREFLIGHT:
 			print_no_write_guidance();

--- a/src/cli.c
+++ b/src/cli.c
@@ -2,9 +2,14 @@
 
 #include "cli.h"
 
+#include "block_device.h"
+#include "boot_region.h"
 #include "device.h"
 #include "exfat_resize.h"
+#include "geometry.h"
+#include "sector_adapter.h"
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,6 +21,8 @@
 
 #if defined(_WIN32)
 static const char target_name[] = "DEVICE";
+static const char usage[] = "Usage: exfat-resize DEVICE [SIZE]\n"
+                            "       exfat-resize --grow-partition DEVICE SIZE\n";
 static const char introduction[] =
     "Grow an existing exFAT filesystem in a Windows image file or logical volume.";
 static const char target_description[] =
@@ -23,20 +30,24 @@ static const char target_description[] =
     "                     volume-GUID path with the exFAT main boot sector\n"
     "                     at sector zero";
 static const char documentation_lead[] = "";
+static const char platform_options[] =
+    "  --grow-partition   Grow a basic partition to explicit SIZE when needed\n";
 static const char platform_note[] =
     "\nPhysical-disk paths such as \\\\.\\PhysicalDrive0 are not supported.\n";
 #else
 static const char target_name[] = "DEVICE";
+static const char usage[] = "Usage: exfat-resize DEVICE [SIZE]\n";
 static const char introduction[] = "Grow an existing exFAT filesystem.";
 static const char target_description[] = "Regular file or raw block device with the exFAT\n"
                                          "                     main boot sector at sector zero";
 static const char documentation_lead[] = "  See exfat-resize(8).\n";
+static const char platform_options[] = "";
 static const char platform_note[] = "";
 #endif
 
 static void print_usage(FILE *stream)
 {
-	fprintf(stream, "Usage: exfat-resize %s [SIZE]\n", target_name);
+	fputs(usage, stream);
 }
 
 static void print_no_write_guidance(void)
@@ -55,7 +66,7 @@ int cli_report_startup_error(const char *message)
 
 static void print_help(void)
 {
-	printf("Usage: exfat-resize %s [SIZE]\n"
+	printf("%s"
 	       "\n"
 	       "%s\n"
 	       "\n"
@@ -65,6 +76,7 @@ static void print_help(void)
 	       "                     (default: all available space)\n"
 	       "\n"
 	       "Options:\n"
+	       "%s"
 	       "  -h, --help         Show this help message\n"
 	       "  -V, --version      Show version information\n"
 	       "\n"
@@ -77,7 +89,7 @@ static void print_help(void)
 	       "  recovery instructions in README.md distributed with exfat-resize or at:\n"
 	       "    https://github.com/huven/exfat-resize#safety\n"
 	       "%s",
-	    target_name, introduction, target_name, target_description, documentation_lead,
+	    usage, introduction, target_name, target_description, platform_options, documentation_lead,
 	    platform_note);
 }
 
@@ -166,6 +178,38 @@ static int parse_size(const char *text, uint64_t *value)
 	return 0;
 }
 
+static enum exfat_resize_error validate_source_boot_regions(
+    const struct exfat_resize_block_device *device)
+{
+	struct exfat_resize_sector_adapter adapter;
+	struct exfat_resize_geometry geometry;
+	enum exfat_resize_error result;
+	unsigned char *buffer;
+	uint32_t filesystem_sector_size;
+
+	buffer = malloc(EXFAT_RESIZE_MAX_SECTOR_SIZE);
+	if (buffer == NULL)
+		return EXFAT_RESIZE_OUT_OF_MEMORY;
+	result = exfat_resize_validate_block_device(device);
+	if (result == EXFAT_RESIZE_SUCCESS)
+		result = exfat_resize_probe_sector_size(
+		    device, buffer, EXFAT_RESIZE_MAX_SECTOR_SIZE, &filesystem_sector_size);
+	if (result == EXFAT_RESIZE_SUCCESS)
+		result = exfat_resize_adapt_block_device(device, filesystem_sector_size, &adapter);
+	if (result == EXFAT_RESIZE_SUCCESS)
+		result = exfat_resize_read_boot_regions(
+		    &adapter.device, buffer, EXFAT_RESIZE_MAX_SECTOR_SIZE, &geometry);
+	free(buffer);
+	return result;
+}
+
+static void print_partition_grown_guidance(void)
+{
+	fprintf(stderr,
+	    "exfat-resize: the partition was enlarged, but the filesystem remains unchanged; "
+	    "verify the partition size before retrying and do not shrink it\n");
+}
+
 int cli_main(int argc, char **argv)
 {
 	struct exfat_resize_options options;
@@ -178,6 +222,8 @@ int cli_main(int argc, char **argv)
 	char io_error[256];
 	int positional_count = 0;
 	int parse_options = 1;
+	int grow_partition = 0;
+	int partition_grown = 0;
 	int status = EXIT_FAILURE;
 	int index;
 
@@ -193,6 +239,10 @@ int cli_main(int argc, char **argv)
 		if (parse_options && strcmp(argv[index], "--version") == 0) {
 			printf("exfat-resize %s\n", EXFAT_RESIZE_BUILD_VERSION);
 			return EXIT_SUCCESS;
+		}
+		if (parse_options && strcmp(argv[index], "--grow-partition") == 0) {
+			grow_partition = 1;
+			continue;
 		}
 		if (parse_options && argv[index][0] == '-' && argv[index][1] != '\0' &&
 		    argv[index][1] != '-') {
@@ -230,6 +280,19 @@ int cli_main(int argc, char **argv)
 		print_no_write_guidance();
 		return EXIT_FAILURE;
 	}
+	if (grow_partition && positional_count != 2) {
+		fprintf(stderr, "exfat-resize: --grow-partition requires an explicit SIZE\n");
+		print_no_write_guidance();
+		return EXIT_FAILURE;
+	}
+#if !defined(_WIN32)
+	if (grow_partition) {
+		fprintf(stderr,
+		    "exfat-resize: --grow-partition is supported only for logical Windows volumes\n");
+		print_no_write_guidance();
+		return EXIT_FAILURE;
+	}
+#endif
 
 	device_init(&device);
 	if (device_open(&device, positional[0], error, sizeof(error)) != 0) {
@@ -239,6 +302,51 @@ int cli_main(int argc, char **argv)
 	}
 	if (positional_count != 2)
 		target = device.block_device.sector_count * (uint64_t)device.block_device.sector_size;
+	if (grow_partition) {
+		uint64_t current_size;
+
+		if (device.block_device.sector_count >
+		    UINT64_MAX / (uint64_t)device.block_device.sector_size) {
+			fprintf(stderr, "exfat-resize: logical volume size is too large\n");
+			print_no_write_guidance();
+			goto out;
+		}
+		current_size = device.block_device.sector_count * (uint64_t)device.block_device.sector_size;
+		if (target > current_size) {
+			/*
+			 * The library's complete preflight needs the requested target to fit the
+			 * device. Validate the source boot regions before changing that device's
+			 * partition, then let the normal resize perform the full preflight.
+			 */
+			result = validate_source_boot_regions(&device.block_device);
+			if (result != EXFAT_RESIZE_SUCCESS) {
+				fprintf(stderr,
+				    "exfat-resize: cannot grow partition: source validation failed: %s\n",
+				    resize_error(result));
+				if (result == EXFAT_RESIZE_IO_ERROR && device.io_error_operation != NULL) {
+					device_format_io_error(&device, io_error, sizeof(io_error));
+					fprintf(stderr, "exfat-resize: %s %s: %s\n", device.io_error_operation,
+					    positional[0], io_error);
+				}
+				print_no_write_guidance();
+				goto out;
+			}
+		}
+		if (device_grow_partition(
+		        &device, positional[0], target, &partition_grown, error, sizeof(error)) != 0) {
+			fprintf(stderr, "exfat-resize: %s\n", error);
+			if (partition_grown)
+				print_partition_grown_guidance();
+			else
+				print_no_write_guidance();
+			goto out;
+		}
+		if (partition_grown) {
+			printf("exfat-resize: grew the partition containing %s to %" PRIu64 " bytes\n",
+			    positional[0],
+			    device.block_device.sector_count * (uint64_t)device.block_device.sector_size);
+		}
+	}
 	options.allocator.context = NULL;
 	options.allocator.allocate = allocate_memory;
 	options.allocator.deallocate = deallocate_memory;
@@ -254,6 +362,8 @@ int cli_main(int argc, char **argv)
 		switch (stage) {
 		case EXFAT_RESIZE_STAGE_PREFLIGHT:
 			print_no_write_guidance();
+			if (partition_grown)
+				print_partition_grown_guidance();
 			break;
 		case EXFAT_RESIZE_STAGE_PREPARING:
 			fprintf(stderr,

--- a/src/cli.c
+++ b/src/cli.c
@@ -1,26 +1,39 @@
 /* SPDX-License-Identifier: MIT */
 
-#define _POSIX_C_SOURCE 200809L
+#include "cli.h"
 
 #include "device.h"
 #include "exfat_resize.h"
 
-#include <errno.h>
-#include <getopt.h>
-#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #ifndef EXFAT_RESIZE_BUILD_VERSION
 #error "EXFAT_RESIZE_BUILD_VERSION must be provided by the build system"
 #endif
 
+#if defined(_WIN32)
+static const char target_name[] = "IMAGE";
+static const char introduction[] = "Grow an existing exFAT filesystem in a Windows image file.";
+static const char target_description[] = "Regular image file with the exFAT main boot sector\n"
+                                         "                     at sector zero";
+static const char documentation_lead[] = "";
+static const char platform_note[] =
+    "\nWindows volumes such as E: and volume-GUID paths are not supported yet.\n";
+#else
+static const char target_name[] = "DEVICE";
+static const char introduction[] = "Grow an existing exFAT filesystem.";
+static const char target_description[] = "Regular file or raw block device with the exFAT\n"
+                                         "                     main boot sector at sector zero";
+static const char documentation_lead[] = "  See exfat-resize(8).\n";
+static const char platform_note[] = "";
+#endif
+
 static void print_usage(FILE *stream)
 {
-	fprintf(stream, "Usage: exfat-resize DEVICE [SIZE]\n");
+	fprintf(stream, "Usage: exfat-resize %s [SIZE]\n", target_name);
 }
 
 static void print_no_write_guidance(void)
@@ -30,15 +43,21 @@ static void print_no_write_guidance(void)
 	    "appropriate\n");
 }
 
+int cli_report_startup_error(const char *message)
+{
+	fprintf(stderr, "exfat-resize: %s\n", message);
+	print_no_write_guidance();
+	return EXIT_FAILURE;
+}
+
 static void print_help(void)
 {
-	printf("Usage: exfat-resize DEVICE [SIZE]\n"
+	printf("Usage: exfat-resize %s [SIZE]\n"
 	       "\n"
-	       "Grow an existing exFAT filesystem.\n"
+	       "%s\n"
 	       "\n"
 	       "Arguments:\n"
-	       "  DEVICE             Regular file or raw block device with the exFAT\n"
-	       "                     main boot sector at sector zero\n"
+	       "  %-18s %s\n"
 	       "  SIZE               Desired filesystem size in bytes\n"
 	       "                     (default: all available space)\n"
 	       "\n"
@@ -50,10 +69,13 @@ static void print_help(void)
 	       "  Make and verify a backup before using this tool.\n"
 	       "\n"
 	       "Documentation:\n"
-	       "  See exfat-resize(8).\n"
+	       "%s"
 	       "  Read the safety requirements, supported-filesystem limitations, and\n"
 	       "  recovery instructions in README.md distributed with exfat-resize or at:\n"
-	       "    https://github.com/huven/exfat-resize#safety\n");
+	       "    https://github.com/huven/exfat-resize#safety\n"
+	       "%s",
+	    target_name, introduction, target_name, target_description, documentation_lead,
+	    platform_note);
 }
 
 static const char *resize_error(enum exfat_resize_error error)
@@ -120,70 +142,100 @@ static void deallocate_memory(void *context, void *memory, size_t size)
 
 static int parse_size(const char *text, uint64_t *value)
 {
-	char *end;
-	uintmax_t parsed;
+	uint64_t parsed = 0;
 
-	if (*text == '\0' || *text == '-' || *text == '+')
+	if (*text == '\0')
 		return -1;
-	errno = 0;
-	parsed = strtoumax(text, &end, 10);
-	if (errno == ERANGE || *end != '\0' || parsed == 0 || parsed > UINT64_MAX)
+	while (*text != '\0') {
+		uint64_t digit;
+
+		if (*text < '0' || *text > '9')
+			return -1;
+		digit = (uint64_t)(*text - '0');
+		if (parsed > (UINT64_MAX - digit) / 10)
+			return -1;
+		parsed = parsed * 10 + digit;
+		++text;
+	}
+	if (parsed == 0)
 		return -1;
-	*value = (uint64_t)parsed;
+	*value = parsed;
 	return 0;
 }
 
-int main(int argc, char **argv)
+int cli_main(int argc, char **argv)
 {
-	static const struct option long_options[] = {
-		{ "help", no_argument, NULL, 'h' },
-		{ "version", no_argument, NULL, 'V' },
-		{ NULL, 0, NULL, 0 },
-	};
 	struct exfat_resize_options options;
-	struct device device = { .fd = -1 };
+	struct device device;
 	enum exfat_resize_error result;
 	enum exfat_resize_stage stage;
+	const char *positional[2];
 	uint64_t target = 0;
 	char error[512];
-	int option;
+	char io_error[256];
+	int positional_count = 0;
+	int parse_options = 1;
 	int status = EXIT_FAILURE;
+	int index;
 
-	opterr = 0;
-	while ((option = getopt_long(argc, argv, "hV", long_options, NULL)) != -1) {
-		switch (option) {
-		case 'h':
+	for (index = 1; index < argc; ++index) {
+		if (parse_options && strcmp(argv[index], "--") == 0) {
+			parse_options = 0;
+			continue;
+		}
+		if (parse_options && strcmp(argv[index], "--help") == 0) {
 			print_help();
 			return EXIT_SUCCESS;
-		case 'V':
+		}
+		if (parse_options && strcmp(argv[index], "--version") == 0) {
 			printf("exfat-resize %s\n", EXFAT_RESIZE_BUILD_VERSION);
 			return EXIT_SUCCESS;
-		default:
+		}
+		if (parse_options && argv[index][0] == '-' && argv[index][1] != '\0' &&
+		    argv[index][1] != '-') {
+			if (argv[index][1] == 'h') {
+				print_help();
+				return EXIT_SUCCESS;
+			}
+			if (argv[index][1] == 'V') {
+				printf("exfat-resize %s\n", EXFAT_RESIZE_BUILD_VERSION);
+				return EXIT_SUCCESS;
+			}
 			print_usage(stderr);
 			print_no_write_guidance();
 			return EXIT_FAILURE;
 		}
+		if (parse_options && argv[index][0] == '-' && argv[index][1] != '\0') {
+			print_usage(stderr);
+			print_no_write_guidance();
+			return EXIT_FAILURE;
+		}
+		if (positional_count == 2) {
+			print_usage(stderr);
+			print_no_write_guidance();
+			return EXIT_FAILURE;
+		}
+		positional[positional_count++] = argv[index];
 	}
-	argc -= optind;
-	argv += optind;
-	if (argc < 1 || argc > 2) {
+	if (positional_count < 1) {
 		print_usage(stderr);
 		print_no_write_guidance();
 		return EXIT_FAILURE;
 	}
-	if (argc == 2 && parse_size(argv[1], &target) != 0) {
-		fprintf(stderr, "exfat-resize: invalid size: %s\n", argv[1]);
+	if (positional_count == 2 && parse_size(positional[1], &target) != 0) {
+		fprintf(stderr, "exfat-resize: invalid size: %s\n", positional[1]);
 		print_no_write_guidance();
 		return EXIT_FAILURE;
 	}
-	if (device_open(&device, argv[0], error, sizeof(error)) != 0) {
+
+	device_init(&device);
+	if (device_open(&device, positional[0], error, sizeof(error)) != 0) {
 		fprintf(stderr, "exfat-resize: %s\n", error);
 		print_no_write_guidance();
 		return EXIT_FAILURE;
 	}
-	if (argc != 2) {
+	if (positional_count != 2)
 		target = device.block_device.sector_count * (uint64_t)device.block_device.sector_size;
-	}
 	options.allocator.context = NULL;
 	options.allocator.allocate = allocate_memory;
 	options.allocator.deallocate = deallocate_memory;
@@ -192,8 +244,9 @@ int main(int argc, char **argv)
 	if (result != EXFAT_RESIZE_SUCCESS) {
 		fprintf(stderr, "exfat-resize: resize failed: %s\n", resize_error(result));
 		if (result == EXFAT_RESIZE_IO_ERROR && device.io_error_operation != NULL) {
-			fprintf(stderr, "exfat-resize: %s %s: %s\n", device.io_error_operation, argv[0],
-			    strerror(device.io_error_number));
+			device_format_io_error(&device, io_error, sizeof(io_error));
+			fprintf(stderr, "exfat-resize: %s %s: %s\n", device.io_error_operation, positional[0],
+			    io_error);
 		}
 		switch (stage) {
 		case EXFAT_RESIZE_STAGE_PREFLIGHT:
@@ -219,7 +272,7 @@ int main(int argc, char **argv)
 		}
 		goto out;
 	}
-	printf("exfat-resize: resized %s\n", argv[0]);
+	printf("exfat-resize: resized %s\n", positional[0]);
 	status = EXIT_SUCCESS;
 
 out:

--- a/src/cli.h
+++ b/src/cli.h
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef EXFAT_RESIZE_CLI_H
+#define EXFAT_RESIZE_CLI_H
+
+int cli_main(int argc, char **argv);
+int cli_report_startup_error(const char *message);
+
+#endif

--- a/src/device.h
+++ b/src/device.h
@@ -16,6 +16,8 @@ struct device {
 #if defined(_WIN32)
 	HANDLE handle;
 	DWORD io_error_number;
+	void *volume_io_buffer;
+	size_t volume_io_buffer_size;
 #else
 	int fd;
 	int is_regular_file;

--- a/src/device.h
+++ b/src/device.h
@@ -29,6 +29,12 @@ struct device {
 
 void device_init(struct device *device);
 int device_open(struct device *device, const char *path, char *error, size_t error_size);
+int device_grow_partition(struct device *device,
+    const char *path,
+    uint64_t target_size,
+    int *partition_grown,
+    char *error,
+    size_t error_size);
 int device_dismount(struct device *device, const char *path, char *error, size_t error_size);
 void device_format_io_error(const struct device *device, char *error, size_t error_size);
 void device_close(struct device *device);

--- a/src/device.h
+++ b/src/device.h
@@ -29,6 +29,7 @@ struct device {
 
 void device_init(struct device *device);
 int device_open(struct device *device, const char *path, char *error, size_t error_size);
+int device_dismount(struct device *device, const char *path, char *error, size_t error_size);
 void device_format_io_error(const struct device *device, char *error, size_t error_size);
 void device_close(struct device *device);
 

--- a/src/device.h
+++ b/src/device.h
@@ -8,15 +8,26 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 struct device {
+#if defined(_WIN32)
+	HANDLE handle;
+	DWORD io_error_number;
+#else
 	int fd;
 	int is_regular_file;
-	const char *io_error_operation;
 	int io_error_number;
+#endif
+	const char *io_error_operation;
 	struct exfat_resize_block_device block_device;
 };
 
+void device_init(struct device *device);
 int device_open(struct device *device, const char *path, char *error, size_t error_size);
+void device_format_io_error(const struct device *device, char *error, size_t error_size);
 void device_close(struct device *device);
 
 #endif

--- a/src/posix/device.c
+++ b/src/posix/device.c
@@ -192,6 +192,15 @@ fail_after_open:
 	return -1;
 }
 
+int device_dismount(struct device *device, const char *path, char *error, size_t error_size)
+{
+	(void)device;
+	(void)path;
+	(void)error;
+	(void)error_size;
+	return 0;
+}
+
 void device_close(struct device *device)
 {
 	if (device->fd >= 0)

--- a/src/posix/device.c
+++ b/src/posix/device.c
@@ -71,6 +71,12 @@ static void record_io_error(struct device *device, const char *operation, int er
 	device->io_error_number = error_number;
 }
 
+void device_init(struct device *device)
+{
+	(void)memset(device, 0, sizeof(*device));
+	device->fd = -1;
+}
+
 int device_open(struct device *device, const char *path, char *error, size_t error_size)
 {
 	struct stat st;
@@ -191,6 +197,11 @@ void device_close(struct device *device)
 	if (device->fd >= 0)
 		(void)close(device->fd);
 	device->fd = -1;
+}
+
+void device_format_io_error(const struct device *device, char *error, size_t error_size)
+{
+	(void)snprintf(error, error_size, "%s", strerror(device->io_error_number));
 }
 
 static int transfer(

--- a/src/posix/device.c
+++ b/src/posix/device.c
@@ -192,6 +192,21 @@ fail_after_open:
 	return -1;
 }
 
+int device_grow_partition(struct device *device,
+    const char *path,
+    uint64_t target_size,
+    int *partition_grown,
+    char *error,
+    size_t error_size)
+{
+	(void)device;
+	(void)target_size;
+	*partition_grown = 0;
+	(void)snprintf(error, error_size,
+	    "%s: --grow-partition is supported only for logical Windows volumes", path);
+	return -1;
+}
+
 int device_dismount(struct device *device, const char *path, char *error, size_t error_size)
 {
 	(void)device;

--- a/src/posix/entry.c
+++ b/src/posix/entry.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "cli.h"
+
+int main(int argc, char **argv)
+{
+	return cli_main(argc, argv);
+}

--- a/src/windows/device.c
+++ b/src/windows/device.c
@@ -59,7 +59,10 @@ static void windows_error_message(DWORD error_number, char *message, size_t size
 
 static void set_error(char *error, size_t size, const char *path, const char *message)
 {
-	(void)snprintf(error, size, "%s: %s", path, message);
+	size_t length = strlen(path);
+	const char *separator = length != 0 && path[length - 1] == ':' ? " " : ": ";
+
+	(void)snprintf(error, size, "%s%s%s", path, separator, message);
 }
 
 static void set_windows_error(char *error, size_t size, const char *path, DWORD error_number)
@@ -238,6 +241,10 @@ static int volume_sector_sizes(HANDLE handle,
 			    error, error_size, path, "cannot determine the volume sector size", GetLastError());
 			return -1;
 		}
+		if (returned < sizeof(geometry.Geometry)) {
+			set_error(error, error_size, path, "the volume returned invalid disk geometry");
+			return -1;
+		}
 		logical = geometry.Geometry.BytesPerSector;
 		physical = logical;
 	}
@@ -327,6 +334,10 @@ static int open_volume(struct device *device, const char *path, char *error, siz
 	        &returned, NULL)) {
 		set_windows_operation_error(
 		    error, error_size, path, "cannot determine the volume size", GetLastError());
+		goto fail_after_open;
+	}
+	if (returned < sizeof(length)) {
+		set_error(error, error_size, path, "the volume returned an invalid size");
 		goto fail_after_open;
 	}
 	if (length.Length.QuadPart < sector_size) {

--- a/src/windows/device.c
+++ b/src/windows/device.c
@@ -1,0 +1,296 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "device.h"
+
+#include "block_device.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int block_device_read(
+    void *context, uint64_t first_sector, uint32_t sector_count, void *buffer);
+static int block_device_write(
+    void *context, uint64_t first_sector, uint32_t sector_count, const void *buffer);
+static int block_device_sync(void *context);
+
+static void windows_error_message(DWORD error_number, char *message, size_t size)
+{
+	wchar_t wide_message[256];
+	char utf8_message[1024];
+	DWORD length;
+	int converted;
+
+	if (size == 0)
+		return;
+	length = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
+	    error_number, 0, wide_message, (DWORD)(sizeof(wide_message) / sizeof(wide_message[0])),
+	    NULL);
+	if (length == 0) {
+		(void)snprintf(message, size, "Windows error %lu", (unsigned long)error_number);
+		return;
+	}
+	while (length > 0 &&
+	    (wide_message[length - 1] == L'\r' || wide_message[length - 1] == L'\n' ||
+	        wide_message[length - 1] == L' ')) {
+		wide_message[--length] = L'\0';
+	}
+	converted = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wide_message, -1, utf8_message,
+	    (int)sizeof(utf8_message), NULL, NULL);
+	if (converted == 0) {
+		(void)snprintf(message, size, "Windows error %lu", (unsigned long)error_number);
+		return;
+	}
+	(void)snprintf(message, size, "%s", utf8_message);
+}
+
+static void set_error(char *error, size_t size, const char *path, const char *message)
+{
+	(void)snprintf(error, size, "%s: %s", path, message);
+}
+
+static void set_windows_error(char *error, size_t size, const char *path, DWORD error_number)
+{
+	char message[1024];
+
+	windows_error_message(error_number, message, sizeof(message));
+	set_error(error, size, path, message);
+}
+
+static wchar_t *utf8_path(const char *path, char *error, size_t error_size)
+{
+	wchar_t *converted;
+	int size;
+
+	size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, NULL, 0);
+	if (size == 0) {
+		set_error(error, error_size, path, "path is not valid UTF-8");
+		return NULL;
+	}
+	if ((size_t)size > SIZE_MAX / sizeof(*converted)) {
+		set_error(error, error_size, path, "path is too large");
+		return NULL;
+	}
+	converted = malloc((size_t)size * sizeof(*converted));
+	if (converted == NULL) {
+		set_error(error, error_size, path, "cannot allocate memory for the path");
+		return NULL;
+	}
+	if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, converted, size) == 0) {
+		free(converted);
+		set_error(error, error_size, path, "cannot convert the path to UTF-16");
+		return NULL;
+	}
+	return converted;
+}
+
+static int ascii_letter(char character)
+{
+	return (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z');
+}
+
+static int ascii_equal(char left, char right)
+{
+	if (left >= 'a' && left <= 'z')
+		left -= 'a' - 'A';
+	if (right >= 'a' && right <= 'z')
+		right -= 'a' - 'A';
+	return left == right;
+}
+
+static int starts_with(const char *path, const char *prefix)
+{
+	while (*prefix != '\0') {
+		if (!ascii_equal(*path++, *prefix++))
+			return 0;
+	}
+	return 1;
+}
+
+static int path_separator(char character)
+{
+	return character == '\\' || character == '/';
+}
+
+static int path_uses_unsupported_namespace(const char *path)
+{
+	if (ascii_letter(path[0]) && path[1] == ':' && path[2] == '\0')
+		return 1;
+	if (!path_separator(path[0]) || !path_separator(path[1]) ||
+	    (path[2] != '.' && path[2] != '?') || !path_separator(path[3]))
+		return 0;
+	if (path[2] == '.')
+		return 1;
+
+	/* Permit only long absolute file paths, not volume or NT device namespaces. */
+	if (ascii_letter(path[4]) && path[5] == ':' && path_separator(path[6]))
+		return 0;
+	if (starts_with(path + 4, "UNC\\") || starts_with(path + 4, "UNC/"))
+		return 0;
+	return 1;
+}
+
+static void record_io_error(struct device *device, const char *operation, DWORD error_number)
+{
+	if (device->io_error_operation != NULL)
+		return;
+	device->io_error_operation = operation;
+	device->io_error_number = error_number;
+}
+
+void device_init(struct device *device)
+{
+	(void)memset(device, 0, sizeof(*device));
+	device->handle = INVALID_HANDLE_VALUE;
+}
+
+int device_open(struct device *device, const char *path, char *error, size_t error_size)
+{
+	BY_HANDLE_FILE_INFORMATION information;
+	LARGE_INTEGER file_size;
+	wchar_t *wide_path;
+	HANDLE handle;
+	DWORD error_number;
+	DWORD file_type;
+	const uint32_t sector_size = 512;
+
+	if (path_uses_unsupported_namespace(path)) {
+		set_error(error, error_size, path,
+		    "Windows volume and device paths are not supported yet; use an image file");
+		return -1;
+	}
+	wide_path = utf8_path(path, error, error_size);
+	if (wide_path == NULL)
+		return -1;
+	handle = CreateFileW(wide_path, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
+	    FILE_ATTRIBUTE_NORMAL, NULL);
+	free(wide_path);
+	if (handle == INVALID_HANDLE_VALUE) {
+		error_number = GetLastError();
+		if (error_number == ERROR_SHARING_VIOLATION || error_number == ERROR_LOCK_VIOLATION)
+			set_error(error, error_size, path, "already in use");
+		else
+			set_windows_error(error, error_size, path, error_number);
+		return -1;
+	}
+	file_type = GetFileType(handle);
+	if (file_type != FILE_TYPE_DISK) {
+		set_error(error, error_size, path, "not a regular image file");
+		goto fail_after_open;
+	}
+	if (!GetFileInformationByHandle(handle, &information)) {
+		error_number = GetLastError();
+		set_windows_error(error, error_size, path, error_number);
+		goto fail_after_open;
+	}
+	if ((information.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+		set_error(error, error_size, path, "not a regular image file");
+		goto fail_after_open;
+	}
+	if (!GetFileSizeEx(handle, &file_size)) {
+		set_windows_error(error, error_size, path, GetLastError());
+		goto fail_after_open;
+	}
+	if (file_size.QuadPart < sector_size) {
+		set_error(error, error_size, path, "image file is too small");
+		goto fail_after_open;
+	}
+	if (!exfat_resize_sector_size_is_supported(sector_size)) {
+		set_error(error, error_size, path, "unsupported virtual sector size");
+		goto fail_after_open;
+	}
+
+	device->handle = handle;
+	device->io_error_operation = NULL;
+	device->io_error_number = ERROR_SUCCESS;
+	device->block_device.context = device;
+	device->block_device.sector_size = sector_size;
+	device->block_device.sector_count = (uint64_t)file_size.QuadPart / sector_size;
+	device->block_device.read = block_device_read;
+	device->block_device.write = block_device_write;
+	device->block_device.sync = block_device_sync;
+	return 0;
+
+fail_after_open:
+	(void)CloseHandle(handle);
+	return -1;
+}
+
+void device_close(struct device *device)
+{
+	if (device->handle != INVALID_HANDLE_VALUE)
+		(void)CloseHandle(device->handle);
+	device->handle = INVALID_HANDLE_VALUE;
+}
+
+void device_format_io_error(const struct device *device, char *error, size_t error_size)
+{
+	windows_error_message(device->io_error_number, error, error_size);
+}
+
+static int transfer(
+    struct device *device, void *buffer, uint64_t sector, uint32_t count, int write_data)
+{
+	uint64_t byte_offset;
+	size_t total, done = 0;
+	uint32_t sector_size = device->block_device.sector_size;
+	uint64_t sector_count = device->block_device.sector_count;
+	const size_t maximum_chunk = (size_t)MAXDWORD - (MAXDWORD % sector_size);
+
+	if ((uint64_t)count > sector_count || sector > sector_count - (uint64_t)count ||
+	    count > SIZE_MAX / sector_size)
+		return -1;
+	byte_offset = sector * sector_size;
+	total = (size_t)count * sector_size;
+	while (done < total) {
+		LARGE_INTEGER offset;
+		DWORD transferred;
+		size_t remaining = total - done;
+		DWORD requested = (DWORD)(remaining > maximum_chunk ? maximum_chunk : remaining);
+		BOOL result;
+
+		offset.QuadPart = (LONGLONG)(byte_offset + done);
+		if (!SetFilePointerEx(device->handle, offset, NULL, FILE_BEGIN)) {
+			record_io_error(device, write_data ? "write" : "read", GetLastError());
+			return -1;
+		}
+		if (write_data) {
+			result = WriteFile(device->handle, (const unsigned char *)buffer + done, requested,
+			    &transferred, NULL);
+		} else {
+			result = ReadFile(
+			    device->handle, (unsigned char *)buffer + done, requested, &transferred, NULL);
+		}
+		if (!result || transferred == 0) {
+			DWORD transfer_error = result ? ERROR_HANDLE_EOF : GetLastError();
+			record_io_error(device, write_data ? "write" : "read", transfer_error);
+			return -1;
+		}
+		done += transferred;
+	}
+	return 0;
+}
+
+static int block_device_read(
+    void *context, uint64_t first_sector, uint32_t sector_count, void *buffer)
+{
+	return transfer(context, buffer, first_sector, sector_count, 0);
+}
+
+static int block_device_write(
+    void *context, uint64_t first_sector, uint32_t sector_count, const void *buffer)
+{
+	return transfer(context, (void *)buffer, first_sector, sector_count, 1);
+}
+
+static int block_device_sync(void *context)
+{
+	struct device *device = context;
+
+	if (FlushFileBuffers(device->handle))
+		return 0;
+	record_io_error(device, "synchronize", GetLastError());
+	return -1;
+}

--- a/src/windows/device.c
+++ b/src/windows/device.c
@@ -3,9 +3,9 @@
 #include "device.h"
 
 #include "block_device.h"
+#include "windows/device_internal.h"
 #include "windows/device_path.h"
 
-#include <limits.h>
 #include <malloc.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -15,11 +15,7 @@
 #include <wchar.h>
 #include <winioctl.h>
 
-#define DRIVE_LAYOUT_BUFFER_SIZE ((DWORD)(1024 * 1024))
 #define VOLUME_IO_BUFFER_SIZE ((size_t)1024 * 1024)
-
-static const GUID basic_data_partition_guid = { 0xebd0a0a2, 0xb9e5, 0x4433,
-	{ 0x87, 0xc0, 0x68, 0xb6, 0xb7, 0x26, 0x99, 0xc7 } };
 
 static int block_device_read(
     void *context, uint64_t first_sector, uint32_t sector_count, void *buffer);
@@ -57,7 +53,7 @@ static void windows_error_message(DWORD error_number, char *message, size_t size
 	(void)snprintf(message, size, "%s", utf8_message);
 }
 
-static void set_error(char *error, size_t size, const char *path, const char *message)
+void windows_device_set_error(char *error, size_t size, const char *path, const char *message)
 {
 	size_t length = strlen(path);
 	const char *separator = length != 0 && path[length - 1] == ':' ? " " : ": ";
@@ -70,10 +66,10 @@ static void set_windows_error(char *error, size_t size, const char *path, DWORD 
 	char message[1024];
 
 	windows_error_message(error_number, message, sizeof(message));
-	set_error(error, size, path, message);
+	windows_device_set_error(error, size, path, message);
 }
 
-static void set_windows_operation_error(
+void windows_device_set_operation_error(
     char *error, size_t size, const char *path, const char *operation, DWORD error_number)
 {
 	char message[1024];
@@ -81,7 +77,7 @@ static void set_windows_operation_error(
 
 	windows_error_message(error_number, detail, sizeof(detail));
 	(void)snprintf(message, sizeof(message), "%s: %s", operation, detail);
-	set_error(error, size, path, message);
+	windows_device_set_error(error, size, path, message);
 }
 
 static wchar_t *utf8_path(const char *path, char *error, size_t error_size)
@@ -91,21 +87,21 @@ static wchar_t *utf8_path(const char *path, char *error, size_t error_size)
 
 	size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, NULL, 0);
 	if (size == 0) {
-		set_error(error, error_size, path, "path is not valid UTF-8");
+		windows_device_set_error(error, error_size, path, "path is not valid UTF-8");
 		return NULL;
 	}
 	if ((size_t)size > SIZE_MAX / sizeof(*converted)) {
-		set_error(error, error_size, path, "path is too large");
+		windows_device_set_error(error, error_size, path, "path is too large");
 		return NULL;
 	}
 	converted = malloc((size_t)size * sizeof(*converted));
 	if (converted == NULL) {
-		set_error(error, error_size, path, "cannot allocate memory for the path");
+		windows_device_set_error(error, error_size, path, "cannot allocate memory for the path");
 		return NULL;
 	}
 	if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, converted, size) == 0) {
 		free(converted);
-		set_error(error, error_size, path, "cannot convert the path to UTF-16");
+		windows_device_set_error(error, error_size, path, "cannot convert the path to UTF-16");
 		return NULL;
 	}
 	return converted;
@@ -164,14 +160,14 @@ static int open_image(struct device *device, const char *path, char *error, size
 	if (handle == INVALID_HANDLE_VALUE) {
 		error_number = GetLastError();
 		if (error_number == ERROR_SHARING_VIOLATION || error_number == ERROR_LOCK_VIOLATION)
-			set_error(error, error_size, path, "already in use");
+			windows_device_set_error(error, error_size, path, "already in use");
 		else
 			set_windows_error(error, error_size, path, error_number);
 		return -1;
 	}
 	file_type = GetFileType(handle);
 	if (file_type != FILE_TYPE_DISK) {
-		set_error(error, error_size, path, "not a regular image file");
+		windows_device_set_error(error, error_size, path, "not a regular image file");
 		goto fail_after_open;
 	}
 	if (!GetFileInformationByHandle(handle, &information)) {
@@ -180,7 +176,7 @@ static int open_image(struct device *device, const char *path, char *error, size
 		goto fail_after_open;
 	}
 	if ((information.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
-		set_error(error, error_size, path, "not a regular image file");
+		windows_device_set_error(error, error_size, path, "not a regular image file");
 		goto fail_after_open;
 	}
 	if (!GetFileSizeEx(handle, &file_size)) {
@@ -188,11 +184,11 @@ static int open_image(struct device *device, const char *path, char *error, size
 		goto fail_after_open;
 	}
 	if (file_size.QuadPart < sector_size) {
-		set_error(error, error_size, path, "image file is too small");
+		windows_device_set_error(error, error_size, path, "image file is too small");
 		goto fail_after_open;
 	}
 	if (!exfat_resize_sector_size_is_supported(sector_size)) {
-		set_error(error, error_size, path, "unsupported virtual sector size");
+		windows_device_set_error(error, error_size, path, "unsupported virtual sector size");
 		goto fail_after_open;
 	}
 
@@ -237,12 +233,13 @@ static int volume_sector_sizes(HANDLE handle,
 		(void)memset(&geometry, 0, sizeof(geometry));
 		if (!DeviceIoControl(handle, IOCTL_DISK_GET_DRIVE_GEOMETRY_EX, NULL, 0, &geometry,
 		        sizeof(geometry), &returned, NULL)) {
-			set_windows_operation_error(
+			windows_device_set_operation_error(
 			    error, error_size, path, "cannot determine the volume sector size", GetLastError());
 			return -1;
 		}
 		if (returned < sizeof(geometry.Geometry)) {
-			set_error(error, error_size, path, "the volume returned invalid disk geometry");
+			windows_device_set_error(
+			    error, error_size, path, "the volume returned invalid disk geometry");
 			return -1;
 		}
 		logical = geometry.Geometry.BytesPerSector;
@@ -253,13 +250,13 @@ static int volume_sector_sizes(HANDLE handle,
 
 		(void)snprintf(message, sizeof(message), "unsupported logical sector size %lu",
 		    (unsigned long)logical);
-		set_error(error, error_size, path, message);
+		windows_device_set_error(error, error_size, path, message);
 		return -1;
 	}
 	if (physical == 0)
 		physical = logical;
 	if (physical < logical || !power_of_two(physical)) {
-		set_error(error, error_size, path, "unsupported physical-sector alignment");
+		windows_device_set_error(error, error_size, path, "unsupported physical-sector alignment");
 		return -1;
 	}
 	*logical_sector_size = logical;
@@ -278,7 +275,7 @@ static int volume_control(HANDLE handle,
 
 	if (DeviceIoControl(handle, control, NULL, 0, NULL, 0, &returned, NULL))
 		return 0;
-	set_windows_operation_error(error, error_size, path, operation, GetLastError());
+	windows_device_set_operation_error(error, error_size, path, operation, GetLastError());
 	return -1;
 }
 
@@ -296,7 +293,7 @@ static int open_volume(struct device *device, const char *path, char *error, siz
 	DWORD returned;
 
 	if (windows_normalize_volume_path(path, normalized, sizeof(normalized)) != 0) {
-		set_error(error, error_size, path, "invalid logical-volume path");
+		windows_device_set_error(error, error_size, path, "invalid logical-volume path");
 		return -1;
 	}
 	wide_path = utf8_path(normalized, error, error_size);
@@ -309,9 +306,9 @@ static int open_volume(struct device *device, const char *path, char *error, siz
 	if (handle == INVALID_HANDLE_VALUE) {
 		error_number = GetLastError();
 		if (error_number == ERROR_SHARING_VIOLATION || error_number == ERROR_LOCK_VIOLATION)
-			set_error(error, error_size, path, "already in use");
+			windows_device_set_error(error, error_size, path, "already in use");
 		else if (error_number == ERROR_ACCESS_DENIED)
-			set_windows_operation_error(error, error_size, path,
+			windows_device_set_operation_error(error, error_size, path,
 			    "cannot open the volume; run as Administrator", error_number);
 		else
 			set_windows_error(error, error_size, path, error_number);
@@ -319,7 +316,7 @@ static int open_volume(struct device *device, const char *path, char *error, siz
 	}
 	file_type = GetFileType(handle);
 	if (file_type != FILE_TYPE_DISK) {
-		set_error(error, error_size, path, "not a logical Windows volume");
+		windows_device_set_error(error, error_size, path, "not a logical Windows volume");
 		goto fail_after_open;
 	}
 	if (volume_control(handle, FSCTL_LOCK_VOLUME, path,
@@ -332,21 +329,22 @@ static int open_volume(struct device *device, const char *path, char *error, siz
 	(void)memset(&length, 0, sizeof(length));
 	if (!DeviceIoControl(handle, IOCTL_DISK_GET_LENGTH_INFO, NULL, 0, &length, sizeof(length),
 	        &returned, NULL)) {
-		set_windows_operation_error(
+		windows_device_set_operation_error(
 		    error, error_size, path, "cannot determine the volume size", GetLastError());
 		goto fail_after_open;
 	}
 	if (returned < sizeof(length)) {
-		set_error(error, error_size, path, "the volume returned an invalid size");
+		windows_device_set_error(error, error_size, path, "the volume returned an invalid size");
 		goto fail_after_open;
 	}
 	if (length.Length.QuadPart < sector_size) {
-		set_error(error, error_size, path, "logical volume is too small");
+		windows_device_set_error(error, error_size, path, "logical volume is too small");
 		goto fail_after_open;
 	}
 	io_buffer = _aligned_malloc(VOLUME_IO_BUFFER_SIZE, buffer_alignment);
 	if (io_buffer == NULL) {
-		set_error(error, error_size, path, "cannot allocate aligned volume I/O memory");
+		windows_device_set_error(
+		    error, error_size, path, "cannot allocate aligned volume I/O memory");
 		goto fail_after_open;
 	}
 	if (volume_control(handle, FSCTL_ALLOW_EXTENDED_DASD_IO, path,
@@ -372,360 +370,13 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 	case WINDOWS_DEVICE_PATH_VOLUME:
 		return open_volume(device, path, error, error_size);
 	case WINDOWS_DEVICE_PATH_UNSUPPORTED:
-		set_error(error, error_size, path,
+		windows_device_set_error(error, error_size, path,
 		    "unsupported Windows device path; use an image file, drive letter, or volume-GUID "
 		    "path");
 		return -1;
 	}
-	set_error(error, error_size, path, "unsupported Windows path");
+	windows_device_set_error(error, error_size, path, "unsupported Windows path");
 	return -1;
-}
-
-static int query_partition_information(HANDLE handle,
-    const char *path,
-    PARTITION_INFORMATION_EX *partition,
-    char *error,
-    size_t error_size)
-{
-	DWORD returned;
-	BOOL succeeded;
-
-	(void)memset(partition, 0, sizeof(*partition));
-	succeeded = DeviceIoControl(handle, IOCTL_DISK_GET_PARTITION_INFO_EX, NULL, 0, partition,
-	    sizeof(*partition), &returned, NULL);
-	if (succeeded && returned >= sizeof(*partition))
-		return 0;
-	if (!succeeded)
-		set_windows_operation_error(
-		    error, error_size, path, "cannot identify the volume partition", GetLastError());
-	else
-		set_error(error, error_size, path, "the volume returned invalid partition information");
-	return -1;
-}
-
-static int query_volume_extent(
-    HANDLE handle, const char *path, DISK_EXTENT *extent, char *error, size_t error_size)
-{
-	VOLUME_DISK_EXTENTS extents;
-	DWORD returned;
-	DWORD error_number;
-
-	(void)memset(&extents, 0, sizeof(extents));
-	if (!DeviceIoControl(handle, IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS, NULL, 0, &extents,
-	        sizeof(extents), &returned, NULL)) {
-		error_number = GetLastError();
-		if (error_number == ERROR_MORE_DATA) {
-			set_error(error, error_size, path,
-			    "partition growth requires a volume with one physical disk extent");
-		} else {
-			set_windows_operation_error(error, error_size, path,
-			    "cannot determine the volume's physical disk extent", error_number);
-		}
-		return -1;
-	}
-	if (returned < offsetof(VOLUME_DISK_EXTENTS, Extents) + sizeof(extents.Extents[0]) ||
-	    extents.NumberOfDiskExtents != 1) {
-		set_error(error, error_size, path,
-		    "partition growth requires a volume with one physical disk extent");
-		return -1;
-	}
-	*extent = extents.Extents[0];
-	return 0;
-}
-
-static DRIVE_LAYOUT_INFORMATION_EX *query_drive_layout(
-    HANDLE handle, const char *path, char *error, size_t error_size)
-{
-	DRIVE_LAYOUT_INFORMATION_EX *layout;
-	size_t maximum_partition_count;
-	DWORD returned;
-
-	layout = malloc(DRIVE_LAYOUT_BUFFER_SIZE);
-	if (layout == NULL) {
-		set_error(error, error_size, path, "cannot allocate memory for the disk layout");
-		return NULL;
-	}
-	(void)memset(layout, 0, DRIVE_LAYOUT_BUFFER_SIZE);
-	if (!DeviceIoControl(handle, IOCTL_DISK_GET_DRIVE_LAYOUT_EX, NULL, 0, layout,
-	        DRIVE_LAYOUT_BUFFER_SIZE, &returned, NULL)) {
-		set_windows_operation_error(
-		    error, error_size, path, "cannot read the physical disk layout", GetLastError());
-		free(layout);
-		return NULL;
-	}
-	if (returned < offsetof(DRIVE_LAYOUT_INFORMATION_EX, PartitionEntry)) {
-		set_error(error, error_size, path, "the physical disk returned an invalid layout");
-		free(layout);
-		return NULL;
-	}
-	maximum_partition_count = (returned - offsetof(DRIVE_LAYOUT_INFORMATION_EX, PartitionEntry)) /
-	    sizeof(layout->PartitionEntry[0]);
-	if (layout->PartitionCount > maximum_partition_count) {
-		set_error(error, error_size, path, "the physical disk returned an invalid layout");
-		free(layout);
-		return NULL;
-	}
-	return layout;
-}
-
-static int is_supported_basic_partition(const PARTITION_INFORMATION_EX *partition)
-{
-	if (partition->PartitionStyle == PARTITION_STYLE_GPT)
-		return memcmp(&partition->Gpt.PartitionType, &basic_data_partition_guid,
-		           sizeof(basic_data_partition_guid)) == 0;
-	if (partition->PartitionStyle == PARTITION_STYLE_MBR)
-		return partition->Mbr.PartitionType == PARTITION_IFS;
-	return 0;
-}
-
-static int checked_end(uint64_t start, uint64_t length, uint64_t *end)
-{
-	if (start > UINT64_MAX - length)
-		return -1;
-	*end = start + length;
-	return 0;
-}
-
-int device_grow_partition(struct device *device,
-    const char *path,
-    uint64_t target_size,
-    int *partition_grown,
-    char *error,
-    size_t error_size)
-{
-	DRIVE_LAYOUT_INFORMATION_EX *layout = NULL;
-	PARTITION_INFORMATION_EX partition;
-	PARTITION_INFORMATION_EX *layout_partition = NULL;
-	DISK_GROW_PARTITION request;
-	GET_LENGTH_INFORMATION disk_length;
-	GET_LENGTH_INFORMATION volume_length;
-	DISK_EXTENT extent;
-	wchar_t disk_path[64];
-	HANDLE disk = INVALID_HANDLE_VALUE;
-	uint64_t current_length;
-	uint64_t current_end;
-	uint64_t maximum_end;
-	uint64_t requested_length;
-	uint64_t growth;
-	uint64_t starting_offset;
-	uint32_t sector_size = device->block_device.sector_size;
-	DWORD disk_number;
-	DWORD partition_number;
-	DWORD returned;
-	DWORD error_number;
-	size_t index;
-	int path_length;
-	int result = -1;
-
-	*partition_grown = 0;
-	if (device->volume_io_buffer == NULL) {
-		set_error(
-		    error, error_size, path, "--grow-partition requires a logical Windows volume target");
-		return -1;
-	}
-	if (device->block_device.sector_count > UINT64_MAX / sector_size) {
-		set_error(error, error_size, path, "the logical volume size is too large");
-		return -1;
-	}
-	current_length = device->block_device.sector_count * (uint64_t)sector_size;
-	if (target_size <= current_length)
-		return 0;
-	if (target_size > (uint64_t)LLONG_MAX ||
-	    target_size > UINT64_MAX - ((uint64_t)sector_size - 1)) {
-		set_error(error, error_size, path, "the requested partition size is too large");
-		return -1;
-	}
-	requested_length = (target_size + sector_size - 1) / sector_size * (uint64_t)sector_size;
-	if (requested_length > (uint64_t)LLONG_MAX) {
-		set_error(error, error_size, path, "the requested partition size is too large");
-		return -1;
-	}
-
-	if (query_partition_information(device->handle, path, &partition, error, error_size) != 0 ||
-	    query_volume_extent(device->handle, path, &extent, error, error_size) != 0)
-		return -1;
-	if (partition.IsServicePartition || partition.PartitionNumber == 0 ||
-	    partition.StartingOffset.QuadPart < 0 || partition.PartitionLength.QuadPart <= 0 ||
-	    extent.StartingOffset.QuadPart < 0 || extent.ExtentLength.QuadPart <= 0 ||
-	    (uint64_t)partition.PartitionLength.QuadPart != current_length ||
-	    extent.StartingOffset.QuadPart != partition.StartingOffset.QuadPart ||
-	    extent.ExtentLength.QuadPart != partition.PartitionLength.QuadPart) {
-		set_error(error, error_size, path,
-		    "the volume does not map to one complete basic-disk partition");
-		return -1;
-	}
-	disk_number = extent.DiskNumber;
-	partition_number = partition.PartitionNumber;
-	starting_offset = (uint64_t)partition.StartingOffset.QuadPart;
-
-	path_length = swprintf(disk_path, sizeof(disk_path) / sizeof(disk_path[0]),
-	    L"\\\\.\\PhysicalDrive%lu", (unsigned long)disk_number);
-	if (path_length < 0 || (size_t)path_length >= sizeof(disk_path) / sizeof(disk_path[0])) {
-		set_error(error, error_size, path, "cannot construct the physical disk path");
-		return -1;
-	}
-	disk = CreateFileW(disk_path, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
-	    NULL, OPEN_EXISTING, FILE_FLAG_WRITE_THROUGH, NULL);
-	if (disk == INVALID_HANDLE_VALUE) {
-		error_number = GetLastError();
-		if (error_number == ERROR_ACCESS_DENIED) {
-			set_windows_operation_error(error, error_size, path,
-			    "cannot open the physical disk; run as Administrator", error_number);
-		} else {
-			set_windows_operation_error(
-			    error, error_size, path, "cannot open the physical disk", error_number);
-		}
-		return -1;
-	}
-
-	layout = query_drive_layout(disk, path, error, error_size);
-	if (layout == NULL)
-		goto out;
-	if (!DeviceIoControl(disk, IOCTL_DISK_GET_LENGTH_INFO, NULL, 0, &disk_length,
-	        sizeof(disk_length), &returned, NULL)) {
-		set_windows_operation_error(
-		    error, error_size, path, "cannot determine the physical disk size", GetLastError());
-		goto out;
-	}
-	if (returned < sizeof(disk_length) || disk_length.Length.QuadPart <= 0) {
-		set_error(error, error_size, path, "the physical disk returned an invalid size");
-		goto out;
-	}
-	if (layout->PartitionStyle != partition.PartitionStyle) {
-		set_error(error, error_size, path, "the volume and physical disk partition styles differ");
-		goto out;
-	}
-	for (index = 0; index < layout->PartitionCount; ++index) {
-		PARTITION_INFORMATION_EX *candidate = &layout->PartitionEntry[index];
-
-		if (candidate->PartitionNumber != partition.PartitionNumber)
-			continue;
-		if (layout_partition != NULL || candidate->StartingOffset.QuadPart < 0 ||
-		    candidate->PartitionLength.QuadPart <= 0 ||
-		    candidate->StartingOffset.QuadPart != partition.StartingOffset.QuadPart ||
-		    candidate->PartitionLength.QuadPart != partition.PartitionLength.QuadPart) {
-			set_error(error, error_size, path,
-			    "the volume partition does not match the physical disk layout");
-			goto out;
-		}
-		layout_partition = candidate;
-	}
-	if (layout_partition == NULL || !is_supported_basic_partition(layout_partition)) {
-		set_error(error, error_size, path,
-		    "partition growth supports only basic GPT or MBR data partitions");
-		goto out;
-	}
-	if (checked_end((uint64_t)partition.StartingOffset.QuadPart, current_length, &current_end) !=
-	    0) {
-		set_error(error, error_size, path, "the partition geometry is too large");
-		goto out;
-	}
-	maximum_end = (uint64_t)disk_length.Length.QuadPart;
-	if (layout->PartitionStyle == PARTITION_STYLE_GPT) {
-		uint64_t usable_start;
-
-		if (layout->Gpt.StartingUsableOffset.QuadPart < 0 ||
-		    layout->Gpt.UsableLength.QuadPart <= 0 ||
-		    checked_end((uint64_t)layout->Gpt.StartingUsableOffset.QuadPart,
-		        (uint64_t)layout->Gpt.UsableLength.QuadPart, &maximum_end) != 0) {
-			set_error(error, error_size, path, "the GPT usable range is invalid");
-			goto out;
-		}
-		usable_start = (uint64_t)layout->Gpt.StartingUsableOffset.QuadPart;
-		if (starting_offset < usable_start || current_end > maximum_end ||
-		    maximum_end > (uint64_t)disk_length.Length.QuadPart) {
-			set_error(error, error_size, path, "the partition is outside the GPT usable range");
-			goto out;
-		}
-	}
-	for (index = 0; index < layout->PartitionCount; ++index) {
-		PARTITION_INFORMATION_EX *candidate = &layout->PartitionEntry[index];
-		uint64_t candidate_end;
-		uint64_t candidate_start;
-
-		if (candidate == layout_partition || candidate->StartingOffset.QuadPart < 0 ||
-		    candidate->PartitionLength.QuadPart <= 0)
-			continue;
-		candidate_start = (uint64_t)candidate->StartingOffset.QuadPart;
-		if (checked_end(candidate_start, (uint64_t)candidate->PartitionLength.QuadPart,
-		        &candidate_end) != 0) {
-			set_error(error, error_size, path, "the physical disk layout is too large");
-			goto out;
-		}
-		if (candidate_end > (uint64_t)disk_length.Length.QuadPart) {
-			set_error(error, error_size, path, "a partition extends beyond the physical disk");
-			goto out;
-		}
-		if (candidate_start < current_end && candidate_end > starting_offset) {
-			set_error(error, error_size, path,
-			    "partition growth does not support overlapping physical-disk layout entries");
-			goto out;
-		}
-		if (candidate_start >= current_end && candidate_start < maximum_end)
-			maximum_end = candidate_start;
-	}
-	if (maximum_end < current_end ||
-	    requested_length - current_length > maximum_end - current_end) {
-		set_error(error, error_size, path,
-		    "not enough immediately trailing unallocated space for the requested size");
-		goto out;
-	}
-
-	growth = requested_length - current_length;
-	(void)memset(&request, 0, sizeof(request));
-	request.PartitionNumber = partition_number;
-	request.BytesToGrow.QuadPart = (LONGLONG)growth;
-	if (!DeviceIoControl(
-	        disk, IOCTL_DISK_GROW_PARTITION, &request, sizeof(request), NULL, 0, &returned, NULL)) {
-		set_windows_operation_error(
-		    error, error_size, path, "cannot grow the partition", GetLastError());
-		goto out;
-	}
-	*partition_grown = 1;
-	if (!FlushFileBuffers(disk)) {
-		set_windows_operation_error(error, error_size, path,
-		    "cannot synchronize the enlarged partition table", GetLastError());
-		goto out;
-	}
-	if (!DeviceIoControl(disk, IOCTL_DISK_UPDATE_PROPERTIES, NULL, 0, NULL, 0, &returned, NULL)) {
-		set_windows_operation_error(
-		    error, error_size, path, "cannot refresh the enlarged physical disk", GetLastError());
-		goto out;
-	}
-	(void)DeviceIoControl(
-	    device->handle, IOCTL_DISK_UPDATE_PROPERTIES, NULL, 0, NULL, 0, &returned, NULL);
-	if (query_partition_information(device->handle, path, &partition, error, error_size) != 0 ||
-	    query_volume_extent(device->handle, path, &extent, error, error_size) != 0)
-		goto out;
-	if (!DeviceIoControl(device->handle, IOCTL_DISK_GET_LENGTH_INFO, NULL, 0, &volume_length,
-	        sizeof(volume_length), &returned, NULL)) {
-		set_windows_operation_error(
-		    error, error_size, path, "cannot refresh the enlarged volume size", GetLastError());
-		goto out;
-	}
-	if (returned < sizeof(volume_length) || volume_length.Length.QuadPart <= 0) {
-		set_error(error, error_size, path, "the enlarged volume returned an invalid size");
-		goto out;
-	}
-	if (partition.StartingOffset.QuadPart < 0 || partition.PartitionLength.QuadPart <= 0 ||
-	    partition.PartitionNumber != partition_number ||
-	    (uint64_t)partition.StartingOffset.QuadPart != starting_offset ||
-	    (uint64_t)partition.PartitionLength.QuadPart != requested_length ||
-	    extent.DiskNumber != disk_number ||
-	    extent.StartingOffset.QuadPart != partition.StartingOffset.QuadPart ||
-	    extent.ExtentLength.QuadPart != partition.PartitionLength.QuadPart ||
-	    volume_length.Length.QuadPart != partition.PartitionLength.QuadPart) {
-		set_error(error, error_size, path,
-		    "Windows did not expose the requested enlarged partition geometry");
-		goto out;
-	}
-	device->block_device.sector_count = requested_length / sector_size;
-	result = 0;
-
-out:
-	free(layout);
-	(void)CloseHandle(disk);
-	return result;
 }
 
 int device_dismount(struct device *device, const char *path, char *error, size_t error_size)

--- a/src/windows/device.c
+++ b/src/windows/device.c
@@ -7,13 +7,19 @@
 
 #include <limits.h>
 #include <malloc.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wchar.h>
 #include <winioctl.h>
 
+#define DRIVE_LAYOUT_BUFFER_SIZE ((DWORD)(1024 * 1024))
 #define VOLUME_IO_BUFFER_SIZE ((size_t)1024 * 1024)
+
+static const GUID basic_data_partition_guid = { 0xebd0a0a2, 0xb9e5, 0x4433,
+	{ 0x87, 0xc0, 0x68, 0xb6, 0xb7, 0x26, 0x99, 0xc7 } };
 
 static int block_device_read(
     void *context, uint64_t first_sector, uint32_t sector_count, void *buffer);
@@ -362,6 +368,353 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 	}
 	set_error(error, error_size, path, "unsupported Windows path");
 	return -1;
+}
+
+static int query_partition_information(HANDLE handle,
+    const char *path,
+    PARTITION_INFORMATION_EX *partition,
+    char *error,
+    size_t error_size)
+{
+	DWORD returned;
+	BOOL succeeded;
+
+	(void)memset(partition, 0, sizeof(*partition));
+	succeeded = DeviceIoControl(handle, IOCTL_DISK_GET_PARTITION_INFO_EX, NULL, 0, partition,
+	    sizeof(*partition), &returned, NULL);
+	if (succeeded && returned >= sizeof(*partition))
+		return 0;
+	if (!succeeded)
+		set_windows_operation_error(
+		    error, error_size, path, "cannot identify the volume partition", GetLastError());
+	else
+		set_error(error, error_size, path, "the volume returned invalid partition information");
+	return -1;
+}
+
+static int query_volume_extent(
+    HANDLE handle, const char *path, DISK_EXTENT *extent, char *error, size_t error_size)
+{
+	VOLUME_DISK_EXTENTS extents;
+	DWORD returned;
+	DWORD error_number;
+
+	(void)memset(&extents, 0, sizeof(extents));
+	if (!DeviceIoControl(handle, IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS, NULL, 0, &extents,
+	        sizeof(extents), &returned, NULL)) {
+		error_number = GetLastError();
+		if (error_number == ERROR_MORE_DATA) {
+			set_error(error, error_size, path,
+			    "partition growth requires a volume with one physical disk extent");
+		} else {
+			set_windows_operation_error(error, error_size, path,
+			    "cannot determine the volume's physical disk extent", error_number);
+		}
+		return -1;
+	}
+	if (returned < offsetof(VOLUME_DISK_EXTENTS, Extents) + sizeof(extents.Extents[0]) ||
+	    extents.NumberOfDiskExtents != 1) {
+		set_error(error, error_size, path,
+		    "partition growth requires a volume with one physical disk extent");
+		return -1;
+	}
+	*extent = extents.Extents[0];
+	return 0;
+}
+
+static DRIVE_LAYOUT_INFORMATION_EX *query_drive_layout(
+    HANDLE handle, const char *path, char *error, size_t error_size)
+{
+	DRIVE_LAYOUT_INFORMATION_EX *layout;
+	size_t maximum_partition_count;
+	DWORD returned;
+
+	layout = malloc(DRIVE_LAYOUT_BUFFER_SIZE);
+	if (layout == NULL) {
+		set_error(error, error_size, path, "cannot allocate memory for the disk layout");
+		return NULL;
+	}
+	(void)memset(layout, 0, DRIVE_LAYOUT_BUFFER_SIZE);
+	if (!DeviceIoControl(handle, IOCTL_DISK_GET_DRIVE_LAYOUT_EX, NULL, 0, layout,
+	        DRIVE_LAYOUT_BUFFER_SIZE, &returned, NULL)) {
+		set_windows_operation_error(
+		    error, error_size, path, "cannot read the physical disk layout", GetLastError());
+		free(layout);
+		return NULL;
+	}
+	if (returned < offsetof(DRIVE_LAYOUT_INFORMATION_EX, PartitionEntry)) {
+		set_error(error, error_size, path, "the physical disk returned an invalid layout");
+		free(layout);
+		return NULL;
+	}
+	maximum_partition_count = (returned - offsetof(DRIVE_LAYOUT_INFORMATION_EX, PartitionEntry)) /
+	    sizeof(layout->PartitionEntry[0]);
+	if (layout->PartitionCount > maximum_partition_count) {
+		set_error(error, error_size, path, "the physical disk returned an invalid layout");
+		free(layout);
+		return NULL;
+	}
+	return layout;
+}
+
+static int is_supported_basic_partition(const PARTITION_INFORMATION_EX *partition)
+{
+	if (partition->PartitionStyle == PARTITION_STYLE_GPT)
+		return memcmp(&partition->Gpt.PartitionType, &basic_data_partition_guid,
+		           sizeof(basic_data_partition_guid)) == 0;
+	if (partition->PartitionStyle == PARTITION_STYLE_MBR)
+		return partition->Mbr.PartitionType == PARTITION_IFS;
+	return 0;
+}
+
+static int checked_end(uint64_t start, uint64_t length, uint64_t *end)
+{
+	if (start > UINT64_MAX - length)
+		return -1;
+	*end = start + length;
+	return 0;
+}
+
+int device_grow_partition(struct device *device,
+    const char *path,
+    uint64_t target_size,
+    int *partition_grown,
+    char *error,
+    size_t error_size)
+{
+	DRIVE_LAYOUT_INFORMATION_EX *layout = NULL;
+	PARTITION_INFORMATION_EX partition;
+	PARTITION_INFORMATION_EX *layout_partition = NULL;
+	DISK_GROW_PARTITION request;
+	GET_LENGTH_INFORMATION disk_length;
+	GET_LENGTH_INFORMATION volume_length;
+	DISK_EXTENT extent;
+	wchar_t disk_path[64];
+	HANDLE disk = INVALID_HANDLE_VALUE;
+	uint64_t current_length;
+	uint64_t current_end;
+	uint64_t maximum_end;
+	uint64_t requested_length;
+	uint64_t growth;
+	uint64_t starting_offset;
+	uint32_t sector_size = device->block_device.sector_size;
+	DWORD disk_number;
+	DWORD partition_number;
+	DWORD returned;
+	DWORD error_number;
+	size_t index;
+	int path_length;
+	int result = -1;
+
+	*partition_grown = 0;
+	if (device->volume_io_buffer == NULL) {
+		set_error(
+		    error, error_size, path, "--grow-partition requires a logical Windows volume target");
+		return -1;
+	}
+	if (device->block_device.sector_count > UINT64_MAX / sector_size) {
+		set_error(error, error_size, path, "the logical volume size is too large");
+		return -1;
+	}
+	current_length = device->block_device.sector_count * (uint64_t)sector_size;
+	if (target_size <= current_length)
+		return 0;
+	if (target_size > (uint64_t)LLONG_MAX ||
+	    target_size > UINT64_MAX - ((uint64_t)sector_size - 1)) {
+		set_error(error, error_size, path, "the requested partition size is too large");
+		return -1;
+	}
+	requested_length = (target_size + sector_size - 1) / sector_size * (uint64_t)sector_size;
+	if (requested_length > (uint64_t)LLONG_MAX) {
+		set_error(error, error_size, path, "the requested partition size is too large");
+		return -1;
+	}
+
+	if (query_partition_information(device->handle, path, &partition, error, error_size) != 0 ||
+	    query_volume_extent(device->handle, path, &extent, error, error_size) != 0)
+		return -1;
+	if (partition.IsServicePartition || partition.PartitionNumber == 0 ||
+	    partition.StartingOffset.QuadPart < 0 || partition.PartitionLength.QuadPart <= 0 ||
+	    extent.StartingOffset.QuadPart < 0 || extent.ExtentLength.QuadPart <= 0 ||
+	    (uint64_t)partition.PartitionLength.QuadPart != current_length ||
+	    extent.StartingOffset.QuadPart != partition.StartingOffset.QuadPart ||
+	    extent.ExtentLength.QuadPart != partition.PartitionLength.QuadPart) {
+		set_error(error, error_size, path,
+		    "the volume does not map to one complete basic-disk partition");
+		return -1;
+	}
+	disk_number = extent.DiskNumber;
+	partition_number = partition.PartitionNumber;
+	starting_offset = (uint64_t)partition.StartingOffset.QuadPart;
+
+	path_length = swprintf(disk_path, sizeof(disk_path) / sizeof(disk_path[0]),
+	    L"\\\\.\\PhysicalDrive%lu", (unsigned long)disk_number);
+	if (path_length < 0 || (size_t)path_length >= sizeof(disk_path) / sizeof(disk_path[0])) {
+		set_error(error, error_size, path, "cannot construct the physical disk path");
+		return -1;
+	}
+	disk = CreateFileW(disk_path, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+	    NULL, OPEN_EXISTING, FILE_FLAG_WRITE_THROUGH, NULL);
+	if (disk == INVALID_HANDLE_VALUE) {
+		error_number = GetLastError();
+		if (error_number == ERROR_ACCESS_DENIED) {
+			set_windows_operation_error(error, error_size, path,
+			    "cannot open the physical disk; run as Administrator", error_number);
+		} else {
+			set_windows_operation_error(
+			    error, error_size, path, "cannot open the physical disk", error_number);
+		}
+		return -1;
+	}
+
+	layout = query_drive_layout(disk, path, error, error_size);
+	if (layout == NULL)
+		goto out;
+	if (!DeviceIoControl(disk, IOCTL_DISK_GET_LENGTH_INFO, NULL, 0, &disk_length,
+	        sizeof(disk_length), &returned, NULL)) {
+		set_windows_operation_error(
+		    error, error_size, path, "cannot determine the physical disk size", GetLastError());
+		goto out;
+	}
+	if (returned < sizeof(disk_length) || disk_length.Length.QuadPart <= 0) {
+		set_error(error, error_size, path, "the physical disk returned an invalid size");
+		goto out;
+	}
+	if (layout->PartitionStyle != partition.PartitionStyle) {
+		set_error(error, error_size, path, "the volume and physical disk partition styles differ");
+		goto out;
+	}
+	for (index = 0; index < layout->PartitionCount; ++index) {
+		PARTITION_INFORMATION_EX *candidate = &layout->PartitionEntry[index];
+
+		if (candidate->PartitionNumber != partition.PartitionNumber)
+			continue;
+		if (layout_partition != NULL || candidate->StartingOffset.QuadPart < 0 ||
+		    candidate->PartitionLength.QuadPart <= 0 ||
+		    candidate->StartingOffset.QuadPart != partition.StartingOffset.QuadPart ||
+		    candidate->PartitionLength.QuadPart != partition.PartitionLength.QuadPart) {
+			set_error(error, error_size, path,
+			    "the volume partition does not match the physical disk layout");
+			goto out;
+		}
+		layout_partition = candidate;
+	}
+	if (layout_partition == NULL || !is_supported_basic_partition(layout_partition)) {
+		set_error(error, error_size, path,
+		    "partition growth supports only basic GPT or MBR data partitions");
+		goto out;
+	}
+	if (checked_end((uint64_t)partition.StartingOffset.QuadPart, current_length, &current_end) !=
+	    0) {
+		set_error(error, error_size, path, "the partition geometry is too large");
+		goto out;
+	}
+	maximum_end = (uint64_t)disk_length.Length.QuadPart;
+	if (layout->PartitionStyle == PARTITION_STYLE_GPT) {
+		uint64_t usable_start;
+
+		if (layout->Gpt.StartingUsableOffset.QuadPart < 0 ||
+		    layout->Gpt.UsableLength.QuadPart <= 0 ||
+		    checked_end((uint64_t)layout->Gpt.StartingUsableOffset.QuadPart,
+		        (uint64_t)layout->Gpt.UsableLength.QuadPart, &maximum_end) != 0) {
+			set_error(error, error_size, path, "the GPT usable range is invalid");
+			goto out;
+		}
+		usable_start = (uint64_t)layout->Gpt.StartingUsableOffset.QuadPart;
+		if (starting_offset < usable_start || current_end > maximum_end ||
+		    maximum_end > (uint64_t)disk_length.Length.QuadPart) {
+			set_error(error, error_size, path, "the partition is outside the GPT usable range");
+			goto out;
+		}
+	}
+	for (index = 0; index < layout->PartitionCount; ++index) {
+		PARTITION_INFORMATION_EX *candidate = &layout->PartitionEntry[index];
+		uint64_t candidate_end;
+		uint64_t candidate_start;
+
+		if (candidate == layout_partition || candidate->StartingOffset.QuadPart < 0 ||
+		    candidate->PartitionLength.QuadPart <= 0)
+			continue;
+		candidate_start = (uint64_t)candidate->StartingOffset.QuadPart;
+		if (checked_end(candidate_start, (uint64_t)candidate->PartitionLength.QuadPart,
+		        &candidate_end) != 0) {
+			set_error(error, error_size, path, "the physical disk layout is too large");
+			goto out;
+		}
+		if (candidate_end > (uint64_t)disk_length.Length.QuadPart) {
+			set_error(error, error_size, path, "a partition extends beyond the physical disk");
+			goto out;
+		}
+		if (candidate_start < current_end && candidate_end > starting_offset) {
+			set_error(error, error_size, path,
+			    "partition growth does not support overlapping physical-disk layout entries");
+			goto out;
+		}
+		if (candidate_start >= current_end && candidate_start < maximum_end)
+			maximum_end = candidate_start;
+	}
+	if (maximum_end < current_end ||
+	    requested_length - current_length > maximum_end - current_end) {
+		set_error(error, error_size, path,
+		    "not enough immediately trailing unallocated space for the requested size");
+		goto out;
+	}
+
+	growth = requested_length - current_length;
+	(void)memset(&request, 0, sizeof(request));
+	request.PartitionNumber = partition_number;
+	request.BytesToGrow.QuadPart = (LONGLONG)growth;
+	if (!DeviceIoControl(
+	        disk, IOCTL_DISK_GROW_PARTITION, &request, sizeof(request), NULL, 0, &returned, NULL)) {
+		set_windows_operation_error(
+		    error, error_size, path, "cannot grow the partition", GetLastError());
+		goto out;
+	}
+	*partition_grown = 1;
+	if (!FlushFileBuffers(disk)) {
+		set_windows_operation_error(error, error_size, path,
+		    "cannot synchronize the enlarged partition table", GetLastError());
+		goto out;
+	}
+	if (!DeviceIoControl(disk, IOCTL_DISK_UPDATE_PROPERTIES, NULL, 0, NULL, 0, &returned, NULL)) {
+		set_windows_operation_error(
+		    error, error_size, path, "cannot refresh the enlarged physical disk", GetLastError());
+		goto out;
+	}
+	(void)DeviceIoControl(
+	    device->handle, IOCTL_DISK_UPDATE_PROPERTIES, NULL, 0, NULL, 0, &returned, NULL);
+	if (query_partition_information(device->handle, path, &partition, error, error_size) != 0 ||
+	    query_volume_extent(device->handle, path, &extent, error, error_size) != 0)
+		goto out;
+	if (!DeviceIoControl(device->handle, IOCTL_DISK_GET_LENGTH_INFO, NULL, 0, &volume_length,
+	        sizeof(volume_length), &returned, NULL)) {
+		set_windows_operation_error(
+		    error, error_size, path, "cannot refresh the enlarged volume size", GetLastError());
+		goto out;
+	}
+	if (returned < sizeof(volume_length) || volume_length.Length.QuadPart <= 0) {
+		set_error(error, error_size, path, "the enlarged volume returned an invalid size");
+		goto out;
+	}
+	if (partition.StartingOffset.QuadPart < 0 || partition.PartitionLength.QuadPart <= 0 ||
+	    partition.PartitionNumber != partition_number ||
+	    (uint64_t)partition.StartingOffset.QuadPart != starting_offset ||
+	    (uint64_t)partition.PartitionLength.QuadPart != requested_length ||
+	    extent.DiskNumber != disk_number ||
+	    extent.StartingOffset.QuadPart != partition.StartingOffset.QuadPart ||
+	    extent.ExtentLength.QuadPart != partition.PartitionLength.QuadPart ||
+	    volume_length.Length.QuadPart != partition.PartitionLength.QuadPart) {
+		set_error(error, error_size, path,
+		    "Windows did not expose the requested enlarged partition geometry");
+		goto out;
+	}
+	device->block_device.sector_count = requested_length / sector_size;
+	result = 0;
+
+out:
+	free(layout);
+	(void)CloseHandle(disk);
+	return result;
 }
 
 int device_dismount(struct device *device, const char *path, char *error, size_t error_size)

--- a/src/windows/device.c
+++ b/src/windows/device.c
@@ -333,9 +333,7 @@ static int open_volume(struct device *device, const char *path, char *error, siz
 		goto fail_after_open;
 	}
 	if (volume_control(handle, FSCTL_ALLOW_EXTENDED_DASD_IO, path,
-	        "cannot enable access to the complete volume", error, error_size) != 0 ||
-	    volume_control(handle, FSCTL_DISMOUNT_VOLUME, path, "cannot dismount the volume", error,
-	        error_size) != 0)
+	        "cannot enable access to the complete volume", error, error_size) != 0)
 		goto fail_after_allocation;
 
 	configure_device(device, handle, sector_size, (uint64_t)length.Length.QuadPart / sector_size,
@@ -364,6 +362,14 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 	}
 	set_error(error, error_size, path, "unsupported Windows path");
 	return -1;
+}
+
+int device_dismount(struct device *device, const char *path, char *error, size_t error_size)
+{
+	if (device->volume_io_buffer == NULL)
+		return 0;
+	return volume_control(device->handle, FSCTL_DISMOUNT_VOLUME, path,
+	    "cannot dismount the volume after resizing", error, error_size);
 }
 
 void device_close(struct device *device)

--- a/src/windows/device.c
+++ b/src/windows/device.c
@@ -3,12 +3,17 @@
 #include "device.h"
 
 #include "block_device.h"
+#include "windows/device_path.h"
 
 #include <limits.h>
+#include <malloc.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <winioctl.h>
+
+#define VOLUME_IO_BUFFER_SIZE ((size_t)1024 * 1024)
 
 static int block_device_read(
     void *context, uint64_t first_sector, uint32_t sector_count, void *buffer);
@@ -59,6 +64,17 @@ static void set_windows_error(char *error, size_t size, const char *path, DWORD 
 	set_error(error, size, path, message);
 }
 
+static void set_windows_operation_error(
+    char *error, size_t size, const char *path, const char *operation, DWORD error_number)
+{
+	char message[1024];
+	char detail[768];
+
+	windows_error_message(error_number, detail, sizeof(detail));
+	(void)snprintf(message, sizeof(message), "%s: %s", operation, detail);
+	set_error(error, size, path, message);
+}
+
 static wchar_t *utf8_path(const char *path, char *error, size_t error_size)
 {
 	wchar_t *converted;
@@ -86,52 +102,6 @@ static wchar_t *utf8_path(const char *path, char *error, size_t error_size)
 	return converted;
 }
 
-static int ascii_letter(char character)
-{
-	return (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z');
-}
-
-static int ascii_equal(char left, char right)
-{
-	if (left >= 'a' && left <= 'z')
-		left -= 'a' - 'A';
-	if (right >= 'a' && right <= 'z')
-		right -= 'a' - 'A';
-	return left == right;
-}
-
-static int starts_with(const char *path, const char *prefix)
-{
-	while (*prefix != '\0') {
-		if (!ascii_equal(*path++, *prefix++))
-			return 0;
-	}
-	return 1;
-}
-
-static int path_separator(char character)
-{
-	return character == '\\' || character == '/';
-}
-
-static int path_uses_unsupported_namespace(const char *path)
-{
-	if (ascii_letter(path[0]) && path[1] == ':' && path[2] == '\0')
-		return 1;
-	if (!path_separator(path[0]) || !path_separator(path[1]) ||
-	    (path[2] != '.' && path[2] != '?') || !path_separator(path[3]))
-		return 0;
-	if (path[2] == '.')
-		return 1;
-
-	/* Permit only long absolute file paths, not volume or NT device namespaces. */
-	if (ascii_letter(path[4]) && path[5] == ':' && path_separator(path[6]))
-		return 0;
-	if (starts_with(path + 4, "UNC\\") || starts_with(path + 4, "UNC/"))
-		return 0;
-	return 1;
-}
-
 static void record_io_error(struct device *device, const char *operation, DWORD error_number)
 {
 	if (device->io_error_operation != NULL)
@@ -146,7 +116,27 @@ void device_init(struct device *device)
 	device->handle = INVALID_HANDLE_VALUE;
 }
 
-int device_open(struct device *device, const char *path, char *error, size_t error_size)
+static void configure_device(struct device *device,
+    HANDLE handle,
+    uint32_t sector_size,
+    uint64_t sector_count,
+    void *volume_io_buffer,
+    size_t volume_io_buffer_size)
+{
+	device->handle = handle;
+	device->io_error_operation = NULL;
+	device->io_error_number = ERROR_SUCCESS;
+	device->volume_io_buffer = volume_io_buffer;
+	device->volume_io_buffer_size = volume_io_buffer_size;
+	device->block_device.context = device;
+	device->block_device.sector_size = sector_size;
+	device->block_device.sector_count = sector_count;
+	device->block_device.read = block_device_read;
+	device->block_device.write = block_device_write;
+	device->block_device.sync = block_device_sync;
+}
+
+static int open_image(struct device *device, const char *path, char *error, size_t error_size)
 {
 	BY_HANDLE_FILE_INFORMATION information;
 	LARGE_INTEGER file_size;
@@ -156,11 +146,6 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 	DWORD file_type;
 	const uint32_t sector_size = 512;
 
-	if (path_uses_unsupported_namespace(path)) {
-		set_error(error, error_size, path,
-		    "Windows volume and device paths are not supported yet; use an image file");
-		return -1;
-	}
 	wide_path = utf8_path(path, error, error_size);
 	if (wide_path == NULL)
 		return -1;
@@ -202,19 +187,182 @@ int device_open(struct device *device, const char *path, char *error, size_t err
 		goto fail_after_open;
 	}
 
-	device->handle = handle;
-	device->io_error_operation = NULL;
-	device->io_error_number = ERROR_SUCCESS;
-	device->block_device.context = device;
-	device->block_device.sector_size = sector_size;
-	device->block_device.sector_count = (uint64_t)file_size.QuadPart / sector_size;
-	device->block_device.read = block_device_read;
-	device->block_device.write = block_device_write;
-	device->block_device.sync = block_device_sync;
+	configure_device(
+	    device, handle, sector_size, (uint64_t)file_size.QuadPart / sector_size, NULL, 0);
 	return 0;
 
 fail_after_open:
 	(void)CloseHandle(handle);
+	return -1;
+}
+
+static int power_of_two(DWORD value)
+{
+	return value != 0 && (value & (value - 1)) == 0;
+}
+
+static int volume_sector_sizes(HANDLE handle,
+    const char *path,
+    uint32_t *logical_sector_size,
+    size_t *buffer_alignment,
+    char *error,
+    size_t error_size)
+{
+	STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR alignment;
+	STORAGE_PROPERTY_QUERY query;
+	DISK_GEOMETRY_EX geometry;
+	DWORD returned;
+	DWORD logical, physical;
+
+	(void)memset(&query, 0, sizeof(query));
+	query.PropertyId = StorageAccessAlignmentProperty;
+	query.QueryType = PropertyStandardQuery;
+	(void)memset(&alignment, 0, sizeof(alignment));
+	if (DeviceIoControl(handle, IOCTL_STORAGE_QUERY_PROPERTY, &query, sizeof(query), &alignment,
+	        sizeof(alignment), &returned, NULL) &&
+	    returned >= sizeof(alignment) && alignment.Size >= sizeof(alignment) &&
+	    alignment.BytesPerLogicalSector != 0) {
+		logical = alignment.BytesPerLogicalSector;
+		physical = alignment.BytesPerPhysicalSector;
+	} else {
+		(void)memset(&geometry, 0, sizeof(geometry));
+		if (!DeviceIoControl(handle, IOCTL_DISK_GET_DRIVE_GEOMETRY_EX, NULL, 0, &geometry,
+		        sizeof(geometry), &returned, NULL)) {
+			set_windows_operation_error(
+			    error, error_size, path, "cannot determine the volume sector size", GetLastError());
+			return -1;
+		}
+		logical = geometry.Geometry.BytesPerSector;
+		physical = logical;
+	}
+	if (!exfat_resize_sector_size_is_supported(logical)) {
+		char message[128];
+
+		(void)snprintf(message, sizeof(message), "unsupported logical sector size %lu",
+		    (unsigned long)logical);
+		set_error(error, error_size, path, message);
+		return -1;
+	}
+	if (physical == 0)
+		physical = logical;
+	if (physical < logical || !power_of_two(physical)) {
+		set_error(error, error_size, path, "unsupported physical-sector alignment");
+		return -1;
+	}
+	*logical_sector_size = logical;
+	*buffer_alignment = physical;
+	return 0;
+}
+
+static int volume_control(HANDLE handle,
+    DWORD control,
+    const char *path,
+    const char *operation,
+    char *error,
+    size_t error_size)
+{
+	DWORD returned;
+
+	if (DeviceIoControl(handle, control, NULL, 0, NULL, 0, &returned, NULL))
+		return 0;
+	set_windows_operation_error(error, error_size, path, operation, GetLastError());
+	return -1;
+}
+
+static int open_volume(struct device *device, const char *path, char *error, size_t error_size)
+{
+	GET_LENGTH_INFORMATION length;
+	char normalized[64];
+	wchar_t *wide_path;
+	void *io_buffer = NULL;
+	HANDLE handle;
+	size_t buffer_alignment;
+	uint32_t sector_size;
+	DWORD error_number;
+	DWORD file_type;
+	DWORD returned;
+
+	if (windows_normalize_volume_path(path, normalized, sizeof(normalized)) != 0) {
+		set_error(error, error_size, path, "invalid logical-volume path");
+		return -1;
+	}
+	wide_path = utf8_path(normalized, error, error_size);
+	if (wide_path == NULL)
+		return -1;
+	handle =
+	    CreateFileW(wide_path, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+	        NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_NO_BUFFERING, NULL);
+	free(wide_path);
+	if (handle == INVALID_HANDLE_VALUE) {
+		error_number = GetLastError();
+		if (error_number == ERROR_SHARING_VIOLATION || error_number == ERROR_LOCK_VIOLATION)
+			set_error(error, error_size, path, "already in use");
+		else if (error_number == ERROR_ACCESS_DENIED)
+			set_windows_operation_error(error, error_size, path,
+			    "cannot open the volume; run as Administrator", error_number);
+		else
+			set_windows_error(error, error_size, path, error_number);
+		return -1;
+	}
+	file_type = GetFileType(handle);
+	if (file_type != FILE_TYPE_DISK) {
+		set_error(error, error_size, path, "not a logical Windows volume");
+		goto fail_after_open;
+	}
+	if (volume_control(handle, FSCTL_LOCK_VOLUME, path,
+	        "cannot lock the volume; close files and applications using it and run as "
+	        "Administrator",
+	        error, error_size) != 0)
+		goto fail_after_open;
+	if (volume_sector_sizes(handle, path, &sector_size, &buffer_alignment, error, error_size) != 0)
+		goto fail_after_open;
+	(void)memset(&length, 0, sizeof(length));
+	if (!DeviceIoControl(handle, IOCTL_DISK_GET_LENGTH_INFO, NULL, 0, &length, sizeof(length),
+	        &returned, NULL)) {
+		set_windows_operation_error(
+		    error, error_size, path, "cannot determine the volume size", GetLastError());
+		goto fail_after_open;
+	}
+	if (length.Length.QuadPart < sector_size) {
+		set_error(error, error_size, path, "logical volume is too small");
+		goto fail_after_open;
+	}
+	io_buffer = _aligned_malloc(VOLUME_IO_BUFFER_SIZE, buffer_alignment);
+	if (io_buffer == NULL) {
+		set_error(error, error_size, path, "cannot allocate aligned volume I/O memory");
+		goto fail_after_open;
+	}
+	if (volume_control(handle, FSCTL_ALLOW_EXTENDED_DASD_IO, path,
+	        "cannot enable access to the complete volume", error, error_size) != 0 ||
+	    volume_control(handle, FSCTL_DISMOUNT_VOLUME, path, "cannot dismount the volume", error,
+	        error_size) != 0)
+		goto fail_after_allocation;
+
+	configure_device(device, handle, sector_size, (uint64_t)length.Length.QuadPart / sector_size,
+	    io_buffer, VOLUME_IO_BUFFER_SIZE);
+	return 0;
+
+fail_after_allocation:
+	_aligned_free(io_buffer);
+fail_after_open:
+	(void)CloseHandle(handle);
+	return -1;
+}
+
+int device_open(struct device *device, const char *path, char *error, size_t error_size)
+{
+	switch (windows_classify_device_path(path)) {
+	case WINDOWS_DEVICE_PATH_IMAGE:
+		return open_image(device, path, error, error_size);
+	case WINDOWS_DEVICE_PATH_VOLUME:
+		return open_volume(device, path, error, error_size);
+	case WINDOWS_DEVICE_PATH_UNSUPPORTED:
+		set_error(error, error_size, path,
+		    "unsupported Windows device path; use an image file, drive letter, or volume-GUID "
+		    "path");
+		return -1;
+	}
+	set_error(error, error_size, path, "unsupported Windows path");
 	return -1;
 }
 
@@ -223,6 +371,10 @@ void device_close(struct device *device)
 	if (device->handle != INVALID_HANDLE_VALUE)
 		(void)CloseHandle(device->handle);
 	device->handle = INVALID_HANDLE_VALUE;
+	if (device->volume_io_buffer != NULL)
+		_aligned_free(device->volume_io_buffer);
+	device->volume_io_buffer = NULL;
+	device->volume_io_buffer_size = 0;
 }
 
 void device_format_io_error(const struct device *device, char *error, size_t error_size)
@@ -237,11 +389,13 @@ static int transfer(
 	size_t total, done = 0;
 	uint32_t sector_size = device->block_device.sector_size;
 	uint64_t sector_count = device->block_device.sector_count;
-	const size_t maximum_chunk = (size_t)MAXDWORD - (MAXDWORD % sector_size);
+	size_t maximum_chunk = (size_t)MAXDWORD - (MAXDWORD % sector_size);
 
 	if ((uint64_t)count > sector_count || sector > sector_count - (uint64_t)count ||
 	    count > SIZE_MAX / sector_size)
 		return -1;
+	if (device->volume_io_buffer != NULL && device->volume_io_buffer_size < maximum_chunk)
+		maximum_chunk = device->volume_io_buffer_size;
 	byte_offset = sector * sector_size;
 	total = (size_t)count * sector_size;
 	while (done < total) {
@@ -249,6 +403,8 @@ static int transfer(
 		DWORD transferred;
 		size_t remaining = total - done;
 		DWORD requested = (DWORD)(remaining > maximum_chunk ? maximum_chunk : remaining);
+		void *io_buffer = device->volume_io_buffer != NULL ? device->volume_io_buffer
+		                                                   : (unsigned char *)buffer + done;
 		BOOL result;
 
 		offset.QuadPart = (LONGLONG)(byte_offset + done);
@@ -257,17 +413,20 @@ static int transfer(
 			return -1;
 		}
 		if (write_data) {
-			result = WriteFile(device->handle, (const unsigned char *)buffer + done, requested,
-			    &transferred, NULL);
+			if (device->volume_io_buffer != NULL)
+				(void)memcpy(io_buffer, (const unsigned char *)buffer + done, requested);
+			result = WriteFile(device->handle, io_buffer, requested, &transferred, NULL);
 		} else {
-			result = ReadFile(
-			    device->handle, (unsigned char *)buffer + done, requested, &transferred, NULL);
+			result = ReadFile(device->handle, io_buffer, requested, &transferred, NULL);
 		}
-		if (!result || transferred == 0) {
-			DWORD transfer_error = result ? ERROR_HANDLE_EOF : GetLastError();
+		if (!result || transferred != requested) {
+			DWORD transfer_error =
+			    result ? (write_data ? ERROR_WRITE_FAULT : ERROR_HANDLE_EOF) : GetLastError();
 			record_io_error(device, write_data ? "write" : "read", transfer_error);
 			return -1;
 		}
+		if (!write_data && device->volume_io_buffer != NULL)
+			(void)memcpy((unsigned char *)buffer + done, io_buffer, requested);
 		done += transferred;
 	}
 	return 0;

--- a/src/windows/device_internal.h
+++ b/src/windows/device_internal.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef EXFAT_RESIZE_WINDOWS_DEVICE_INTERNAL_H
+#define EXFAT_RESIZE_WINDOWS_DEVICE_INTERNAL_H
+
+#include <stddef.h>
+#include <windows.h>
+
+void windows_device_set_error(char *error, size_t size, const char *path, const char *message);
+void windows_device_set_operation_error(
+    char *error, size_t size, const char *path, const char *operation, DWORD error_number);
+
+#endif

--- a/src/windows/device_path.c
+++ b/src/windows/device_path.c
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "windows/device_path.h"
+
+#include <string.h>
+
+#define VOLUME_GUID_PREFIX_LENGTH ((size_t)11)
+#define VOLUME_GUID_LENGTH ((size_t)36)
+#define VOLUME_GUID_PATH_LENGTH (VOLUME_GUID_PREFIX_LENGTH + VOLUME_GUID_LENGTH + 1)
+
+static int ascii_letter(char character)
+{
+	return (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z');
+}
+
+static int ascii_hex_digit(char character)
+{
+	return (character >= '0' && character <= '9') || (character >= 'A' && character <= 'F') ||
+	    (character >= 'a' && character <= 'f');
+}
+
+static int ascii_equal(char left, char right)
+{
+	if (left >= 'a' && left <= 'z')
+		left -= 'a' - 'A';
+	if (right >= 'a' && right <= 'z')
+		right -= 'a' - 'A';
+	return left == right;
+}
+
+static int path_separator(char character)
+{
+	return character == '\\' || character == '/';
+}
+
+static int starts_with(const char *path, const char *prefix)
+{
+	while (*prefix != '\0') {
+		if (!ascii_equal(*path++, *prefix++))
+			return 0;
+	}
+	return 1;
+}
+
+static int drive_designator(const char *path, size_t length)
+{
+	return length == 2 && ascii_letter(path[0]) && path[1] == ':';
+}
+
+static int device_namespace(const char *path, size_t length)
+{
+	return length >= 4 && path_separator(path[0]) && path_separator(path[1]) &&
+	    (path[2] == '.' || path[2] == '?') && path_separator(path[3]);
+}
+
+static int volume_guid(const char *path, size_t length)
+{
+	static const size_t hyphens[] = { 8, 13, 18, 23 };
+	const char *guid;
+	size_t index, hyphen_index = 0;
+
+	if ((length != VOLUME_GUID_PATH_LENGTH && length != VOLUME_GUID_PATH_LENGTH + 1) ||
+	    path[2] != '?' || !starts_with(path + 4, "Volume{"))
+		return 0;
+	guid = path + VOLUME_GUID_PREFIX_LENGTH;
+	for (index = 0; index < VOLUME_GUID_LENGTH; ++index) {
+		if (hyphen_index < sizeof(hyphens) / sizeof(hyphens[0]) && index == hyphens[hyphen_index]) {
+			if (guid[index] != '-')
+				return 0;
+			++hyphen_index;
+		} else if (!ascii_hex_digit(guid[index])) {
+			return 0;
+		}
+	}
+	if (guid[VOLUME_GUID_LENGTH] != '}')
+		return 0;
+	return length == VOLUME_GUID_PATH_LENGTH || path_separator(path[length - 1]);
+}
+
+enum windows_device_path_type windows_classify_device_path(const char *path)
+{
+	size_t length = strlen(path);
+
+	if (drive_designator(path, length))
+		return WINDOWS_DEVICE_PATH_VOLUME;
+	if (!device_namespace(path, length))
+		return WINDOWS_DEVICE_PATH_IMAGE;
+	if (path[2] == '.' && length == 6 && drive_designator(path + 4, 2))
+		return WINDOWS_DEVICE_PATH_VOLUME;
+	if (volume_guid(path, length))
+		return WINDOWS_DEVICE_PATH_VOLUME;
+
+	/* Permit long absolute file paths, but no other device namespaces. */
+	if (path[2] == '?' && length >= 7 && ascii_letter(path[4]) && path[5] == ':' &&
+	    path_separator(path[6]))
+		return WINDOWS_DEVICE_PATH_IMAGE;
+	if (path[2] == '?' && length >= 8 &&
+	    (starts_with(path + 4, "UNC\\") || starts_with(path + 4, "UNC/")))
+		return WINDOWS_DEVICE_PATH_IMAGE;
+	return WINDOWS_DEVICE_PATH_UNSUPPORTED;
+}
+
+int windows_normalize_volume_path(const char *path, char *normalized, size_t normalized_size)
+{
+	size_t length = strlen(path);
+
+	if (windows_classify_device_path(path) != WINDOWS_DEVICE_PATH_VOLUME)
+		return -1;
+	if (drive_designator(path, length)) {
+		if (normalized_size < 7)
+			return -1;
+		normalized[0] = '\\';
+		normalized[1] = '\\';
+		normalized[2] = '.';
+		normalized[3] = '\\';
+		normalized[4] = path[0];
+		normalized[5] = ':';
+		normalized[6] = '\0';
+		return 0;
+	}
+	if (path[2] == '.') {
+		if (normalized_size < 7)
+			return -1;
+		normalized[0] = '\\';
+		normalized[1] = '\\';
+		normalized[2] = '.';
+		normalized[3] = '\\';
+		normalized[4] = path[4];
+		normalized[5] = ':';
+		normalized[6] = '\0';
+		return 0;
+	}
+
+	if (normalized_size < VOLUME_GUID_PATH_LENGTH + 1)
+		return -1;
+	(void)memcpy(normalized, "\\\\?\\Volume{", VOLUME_GUID_PREFIX_LENGTH);
+	(void)memcpy(normalized + VOLUME_GUID_PREFIX_LENGTH, path + VOLUME_GUID_PREFIX_LENGTH,
+	    VOLUME_GUID_LENGTH + 1);
+	normalized[VOLUME_GUID_PATH_LENGTH] = '\0';
+	return 0;
+}

--- a/src/windows/device_path.h
+++ b/src/windows/device_path.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef EXFAT_RESIZE_WINDOWS_DEVICE_PATH_H
+#define EXFAT_RESIZE_WINDOWS_DEVICE_PATH_H
+
+#include <stddef.h>
+
+enum windows_device_path_type {
+	WINDOWS_DEVICE_PATH_IMAGE,
+	WINDOWS_DEVICE_PATH_VOLUME,
+	WINDOWS_DEVICE_PATH_UNSUPPORTED
+};
+
+enum windows_device_path_type windows_classify_device_path(const char *path);
+int windows_normalize_volume_path(const char *path, char *normalized, size_t normalized_size);
+
+#endif

--- a/src/windows/entry.c
+++ b/src/windows/entry.c
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "cli.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <windows.h>
+
+static char *utf8_argument(const wchar_t *argument, const char **error)
+{
+	char *converted;
+	int size;
+
+	size = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, argument, -1, NULL, 0, NULL, NULL);
+	if (size == 0) {
+		*error = "command line contains invalid Unicode";
+		return NULL;
+	}
+	converted = malloc((size_t)size);
+	if (converted == NULL) {
+		*error = "cannot allocate memory for the command line";
+		return NULL;
+	}
+	if (WideCharToMultiByte(
+	        CP_UTF8, WC_ERR_INVALID_CHARS, argument, -1, converted, size, NULL, NULL) == 0) {
+		free(converted);
+		*error = "cannot convert the command line to UTF-8";
+		return NULL;
+	}
+	return converted;
+}
+
+int wmain(int argc, wchar_t **wide_argv)
+{
+	const char *error = NULL;
+	char **argv;
+	UINT original_output_code_page;
+	int index;
+	int status = EXIT_FAILURE;
+	int output_code_page_changed;
+
+	original_output_code_page = GetConsoleOutputCP();
+	output_code_page_changed = SetConsoleOutputCP(CP_UTF8);
+	if (argc < 0 || (size_t)argc > SIZE_MAX / sizeof(*argv) - 1) {
+		status = cli_report_startup_error("command line is too large");
+		goto restore_console;
+	}
+	argv = calloc((size_t)argc + 1, sizeof(*argv));
+	if (argv == NULL) {
+		status = cli_report_startup_error("cannot allocate memory for the command line");
+		goto restore_console;
+	}
+	for (index = 0; index < argc; ++index) {
+		argv[index] = utf8_argument(wide_argv[index], &error);
+		if (argv[index] == NULL)
+			break;
+	}
+	if (index == argc)
+		status = cli_main(argc, argv);
+	else
+		status = cli_report_startup_error(error);
+	while (index > 0)
+		free(argv[--index]);
+	free(argv);
+
+restore_console:
+	(void)fflush(NULL);
+	if (output_code_page_changed)
+		(void)SetConsoleOutputCP(original_output_code_page);
+	return status;
+}

--- a/src/windows/partition.c
+++ b/src/windows/partition.c
@@ -1,0 +1,378 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "device.h"
+
+#include "windows/device_internal.h"
+
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#include <winioctl.h>
+
+#define DRIVE_LAYOUT_BUFFER_SIZE ((DWORD)(1024 * 1024))
+
+static const GUID basic_data_partition_guid = { 0xebd0a0a2, 0xb9e5, 0x4433,
+	{ 0x87, 0xc0, 0x68, 0xb6, 0xb7, 0x26, 0x99, 0xc7 } };
+
+static int query_partition_information(HANDLE handle,
+    const char *path,
+    PARTITION_INFORMATION_EX *partition,
+    char *error,
+    size_t error_size)
+{
+	DWORD returned;
+	BOOL succeeded;
+
+	(void)memset(partition, 0, sizeof(*partition));
+	succeeded = DeviceIoControl(handle, IOCTL_DISK_GET_PARTITION_INFO_EX, NULL, 0, partition,
+	    sizeof(*partition), &returned, NULL);
+	if (succeeded && returned >= sizeof(*partition))
+		return 0;
+	if (!succeeded)
+		windows_device_set_operation_error(
+		    error, error_size, path, "cannot identify the volume partition", GetLastError());
+	else
+		windows_device_set_error(
+		    error, error_size, path, "the volume returned invalid partition information");
+	return -1;
+}
+
+static int query_volume_extent(
+    HANDLE handle, const char *path, DISK_EXTENT *extent, char *error, size_t error_size)
+{
+	VOLUME_DISK_EXTENTS extents;
+	DWORD returned;
+	DWORD error_number;
+
+	(void)memset(&extents, 0, sizeof(extents));
+	if (!DeviceIoControl(handle, IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS, NULL, 0, &extents,
+	        sizeof(extents), &returned, NULL)) {
+		error_number = GetLastError();
+		if (error_number == ERROR_MORE_DATA) {
+			windows_device_set_error(error, error_size, path,
+			    "partition growth requires a volume with one physical disk extent");
+		} else {
+			windows_device_set_operation_error(error, error_size, path,
+			    "cannot determine the volume's physical disk extent", error_number);
+		}
+		return -1;
+	}
+	if (returned < offsetof(VOLUME_DISK_EXTENTS, Extents) + sizeof(extents.Extents[0]) ||
+	    extents.NumberOfDiskExtents != 1) {
+		windows_device_set_error(error, error_size, path,
+		    "partition growth requires a volume with one physical disk extent");
+		return -1;
+	}
+	*extent = extents.Extents[0];
+	return 0;
+}
+
+static DRIVE_LAYOUT_INFORMATION_EX *query_drive_layout(
+    HANDLE handle, const char *path, char *error, size_t error_size)
+{
+	DRIVE_LAYOUT_INFORMATION_EX *layout;
+	size_t maximum_partition_count;
+	DWORD returned;
+
+	layout = malloc(DRIVE_LAYOUT_BUFFER_SIZE);
+	if (layout == NULL) {
+		windows_device_set_error(
+		    error, error_size, path, "cannot allocate memory for the disk layout");
+		return NULL;
+	}
+	(void)memset(layout, 0, DRIVE_LAYOUT_BUFFER_SIZE);
+	if (!DeviceIoControl(handle, IOCTL_DISK_GET_DRIVE_LAYOUT_EX, NULL, 0, layout,
+	        DRIVE_LAYOUT_BUFFER_SIZE, &returned, NULL)) {
+		windows_device_set_operation_error(
+		    error, error_size, path, "cannot read the physical disk layout", GetLastError());
+		free(layout);
+		return NULL;
+	}
+	if (returned < offsetof(DRIVE_LAYOUT_INFORMATION_EX, PartitionEntry)) {
+		windows_device_set_error(
+		    error, error_size, path, "the physical disk returned an invalid layout");
+		free(layout);
+		return NULL;
+	}
+	maximum_partition_count = (returned - offsetof(DRIVE_LAYOUT_INFORMATION_EX, PartitionEntry)) /
+	    sizeof(layout->PartitionEntry[0]);
+	if (layout->PartitionCount > maximum_partition_count) {
+		windows_device_set_error(
+		    error, error_size, path, "the physical disk returned an invalid layout");
+		free(layout);
+		return NULL;
+	}
+	return layout;
+}
+
+static int is_supported_basic_partition(const PARTITION_INFORMATION_EX *partition)
+{
+	if (partition->PartitionStyle == PARTITION_STYLE_GPT)
+		return memcmp(&partition->Gpt.PartitionType, &basic_data_partition_guid,
+		           sizeof(basic_data_partition_guid)) == 0;
+	if (partition->PartitionStyle == PARTITION_STYLE_MBR)
+		return partition->Mbr.PartitionType == PARTITION_IFS;
+	return 0;
+}
+
+static int checked_end(uint64_t start, uint64_t length, uint64_t *end)
+{
+	if (start > UINT64_MAX - length)
+		return -1;
+	*end = start + length;
+	return 0;
+}
+
+int device_grow_partition(struct device *device,
+    const char *path,
+    uint64_t target_size,
+    int *partition_grown,
+    char *error,
+    size_t error_size)
+{
+	DRIVE_LAYOUT_INFORMATION_EX *layout = NULL;
+	PARTITION_INFORMATION_EX partition;
+	PARTITION_INFORMATION_EX *layout_partition = NULL;
+	DISK_GROW_PARTITION request;
+	GET_LENGTH_INFORMATION disk_length;
+	GET_LENGTH_INFORMATION volume_length;
+	DISK_EXTENT extent;
+	wchar_t disk_path[64];
+	HANDLE disk = INVALID_HANDLE_VALUE;
+	uint64_t current_length;
+	uint64_t current_end;
+	uint64_t maximum_end;
+	uint64_t requested_length;
+	uint64_t growth;
+	uint64_t starting_offset;
+	uint32_t sector_size = device->block_device.sector_size;
+	DWORD disk_number;
+	DWORD partition_number;
+	DWORD returned;
+	DWORD error_number;
+	size_t index;
+	int path_length;
+	int result = -1;
+
+	*partition_grown = 0;
+	if (device->volume_io_buffer == NULL) {
+		windows_device_set_error(
+		    error, error_size, path, "--grow-partition requires a logical Windows volume target");
+		return -1;
+	}
+	if (device->block_device.sector_count > UINT64_MAX / sector_size) {
+		windows_device_set_error(error, error_size, path, "the logical volume size is too large");
+		return -1;
+	}
+	current_length = device->block_device.sector_count * (uint64_t)sector_size;
+	if (target_size <= current_length)
+		return 0;
+	if (target_size > (uint64_t)LLONG_MAX ||
+	    target_size > UINT64_MAX - ((uint64_t)sector_size - 1)) {
+		windows_device_set_error(
+		    error, error_size, path, "the requested partition size is too large");
+		return -1;
+	}
+	requested_length = (target_size + sector_size - 1) / sector_size * (uint64_t)sector_size;
+	if (requested_length > (uint64_t)LLONG_MAX) {
+		windows_device_set_error(
+		    error, error_size, path, "the requested partition size is too large");
+		return -1;
+	}
+
+	if (query_partition_information(device->handle, path, &partition, error, error_size) != 0 ||
+	    query_volume_extent(device->handle, path, &extent, error, error_size) != 0)
+		return -1;
+	if (partition.IsServicePartition || partition.PartitionNumber == 0 ||
+	    partition.StartingOffset.QuadPart < 0 || partition.PartitionLength.QuadPart <= 0 ||
+	    extent.StartingOffset.QuadPart < 0 || extent.ExtentLength.QuadPart <= 0 ||
+	    (uint64_t)partition.PartitionLength.QuadPart != current_length ||
+	    extent.StartingOffset.QuadPart != partition.StartingOffset.QuadPart ||
+	    extent.ExtentLength.QuadPart != partition.PartitionLength.QuadPart) {
+		windows_device_set_error(error, error_size, path,
+		    "the volume does not map to one complete basic-disk partition");
+		return -1;
+	}
+	disk_number = extent.DiskNumber;
+	partition_number = partition.PartitionNumber;
+	starting_offset = (uint64_t)partition.StartingOffset.QuadPart;
+
+	path_length = swprintf(disk_path, sizeof(disk_path) / sizeof(disk_path[0]),
+	    L"\\\\.\\PhysicalDrive%lu", (unsigned long)disk_number);
+	if (path_length < 0 || (size_t)path_length >= sizeof(disk_path) / sizeof(disk_path[0])) {
+		windows_device_set_error(
+		    error, error_size, path, "cannot construct the physical disk path");
+		return -1;
+	}
+	disk = CreateFileW(disk_path, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+	    NULL, OPEN_EXISTING, FILE_FLAG_WRITE_THROUGH, NULL);
+	if (disk == INVALID_HANDLE_VALUE) {
+		error_number = GetLastError();
+		if (error_number == ERROR_ACCESS_DENIED) {
+			windows_device_set_operation_error(error, error_size, path,
+			    "cannot open the physical disk; run as Administrator", error_number);
+		} else {
+			windows_device_set_operation_error(
+			    error, error_size, path, "cannot open the physical disk", error_number);
+		}
+		return -1;
+	}
+
+	layout = query_drive_layout(disk, path, error, error_size);
+	if (layout == NULL)
+		goto out;
+	if (!DeviceIoControl(disk, IOCTL_DISK_GET_LENGTH_INFO, NULL, 0, &disk_length,
+	        sizeof(disk_length), &returned, NULL)) {
+		windows_device_set_operation_error(
+		    error, error_size, path, "cannot determine the physical disk size", GetLastError());
+		goto out;
+	}
+	if (returned < sizeof(disk_length) || disk_length.Length.QuadPart <= 0) {
+		windows_device_set_error(
+		    error, error_size, path, "the physical disk returned an invalid size");
+		goto out;
+	}
+	if (layout->PartitionStyle != partition.PartitionStyle) {
+		windows_device_set_error(
+		    error, error_size, path, "the volume and physical disk partition styles differ");
+		goto out;
+	}
+	for (index = 0; index < layout->PartitionCount; ++index) {
+		PARTITION_INFORMATION_EX *candidate = &layout->PartitionEntry[index];
+
+		if (candidate->PartitionNumber != partition.PartitionNumber)
+			continue;
+		if (layout_partition != NULL || candidate->StartingOffset.QuadPart < 0 ||
+		    candidate->PartitionLength.QuadPart <= 0 ||
+		    candidate->StartingOffset.QuadPart != partition.StartingOffset.QuadPart ||
+		    candidate->PartitionLength.QuadPart != partition.PartitionLength.QuadPart) {
+			windows_device_set_error(error, error_size, path,
+			    "the volume partition does not match the physical disk layout");
+			goto out;
+		}
+		layout_partition = candidate;
+	}
+	if (layout_partition == NULL || !is_supported_basic_partition(layout_partition)) {
+		windows_device_set_error(error, error_size, path,
+		    "partition growth supports only basic GPT or MBR data partitions");
+		goto out;
+	}
+	if (checked_end((uint64_t)partition.StartingOffset.QuadPart, current_length, &current_end) !=
+	    0) {
+		windows_device_set_error(error, error_size, path, "the partition geometry is too large");
+		goto out;
+	}
+	maximum_end = (uint64_t)disk_length.Length.QuadPart;
+	if (layout->PartitionStyle == PARTITION_STYLE_GPT) {
+		uint64_t usable_start;
+
+		if (layout->Gpt.StartingUsableOffset.QuadPart < 0 ||
+		    layout->Gpt.UsableLength.QuadPart <= 0 ||
+		    checked_end((uint64_t)layout->Gpt.StartingUsableOffset.QuadPart,
+		        (uint64_t)layout->Gpt.UsableLength.QuadPart, &maximum_end) != 0) {
+			windows_device_set_error(error, error_size, path, "the GPT usable range is invalid");
+			goto out;
+		}
+		usable_start = (uint64_t)layout->Gpt.StartingUsableOffset.QuadPart;
+		if (starting_offset < usable_start || current_end > maximum_end ||
+		    maximum_end > (uint64_t)disk_length.Length.QuadPart) {
+			windows_device_set_error(
+			    error, error_size, path, "the partition is outside the GPT usable range");
+			goto out;
+		}
+	}
+	for (index = 0; index < layout->PartitionCount; ++index) {
+		PARTITION_INFORMATION_EX *candidate = &layout->PartitionEntry[index];
+		uint64_t candidate_end;
+		uint64_t candidate_start;
+
+		if (candidate == layout_partition || candidate->StartingOffset.QuadPart < 0 ||
+		    candidate->PartitionLength.QuadPart <= 0)
+			continue;
+		candidate_start = (uint64_t)candidate->StartingOffset.QuadPart;
+		if (checked_end(candidate_start, (uint64_t)candidate->PartitionLength.QuadPart,
+		        &candidate_end) != 0) {
+			windows_device_set_error(
+			    error, error_size, path, "the physical disk layout is too large");
+			goto out;
+		}
+		if (candidate_end > (uint64_t)disk_length.Length.QuadPart) {
+			windows_device_set_error(
+			    error, error_size, path, "a partition extends beyond the physical disk");
+			goto out;
+		}
+		if (candidate_start < current_end && candidate_end > starting_offset) {
+			windows_device_set_error(error, error_size, path,
+			    "partition growth does not support overlapping physical-disk layout entries");
+			goto out;
+		}
+		if (candidate_start >= current_end && candidate_start < maximum_end)
+			maximum_end = candidate_start;
+	}
+	if (maximum_end < current_end ||
+	    requested_length - current_length > maximum_end - current_end) {
+		windows_device_set_error(error, error_size, path,
+		    "not enough immediately trailing unallocated space for the requested size");
+		goto out;
+	}
+
+	growth = requested_length - current_length;
+	(void)memset(&request, 0, sizeof(request));
+	request.PartitionNumber = partition_number;
+	request.BytesToGrow.QuadPart = (LONGLONG)growth;
+	if (!DeviceIoControl(
+	        disk, IOCTL_DISK_GROW_PARTITION, &request, sizeof(request), NULL, 0, &returned, NULL)) {
+		windows_device_set_operation_error(
+		    error, error_size, path, "cannot grow the partition", GetLastError());
+		goto out;
+	}
+	*partition_grown = 1;
+	if (!FlushFileBuffers(disk)) {
+		windows_device_set_operation_error(error, error_size, path,
+		    "cannot synchronize the enlarged partition table", GetLastError());
+		goto out;
+	}
+	if (!DeviceIoControl(disk, IOCTL_DISK_UPDATE_PROPERTIES, NULL, 0, NULL, 0, &returned, NULL)) {
+		windows_device_set_operation_error(
+		    error, error_size, path, "cannot refresh the enlarged physical disk", GetLastError());
+		goto out;
+	}
+	(void)DeviceIoControl(
+	    device->handle, IOCTL_DISK_UPDATE_PROPERTIES, NULL, 0, NULL, 0, &returned, NULL);
+	if (query_partition_information(device->handle, path, &partition, error, error_size) != 0 ||
+	    query_volume_extent(device->handle, path, &extent, error, error_size) != 0)
+		goto out;
+	if (!DeviceIoControl(device->handle, IOCTL_DISK_GET_LENGTH_INFO, NULL, 0, &volume_length,
+	        sizeof(volume_length), &returned, NULL)) {
+		windows_device_set_operation_error(
+		    error, error_size, path, "cannot refresh the enlarged volume size", GetLastError());
+		goto out;
+	}
+	if (returned < sizeof(volume_length) || volume_length.Length.QuadPart <= 0) {
+		windows_device_set_error(
+		    error, error_size, path, "the enlarged volume returned an invalid size");
+		goto out;
+	}
+	if (partition.StartingOffset.QuadPart < 0 || partition.PartitionLength.QuadPart <= 0 ||
+	    partition.PartitionNumber != partition_number ||
+	    (uint64_t)partition.StartingOffset.QuadPart != starting_offset ||
+	    (uint64_t)partition.PartitionLength.QuadPart != requested_length ||
+	    extent.DiskNumber != disk_number ||
+	    extent.StartingOffset.QuadPart != partition.StartingOffset.QuadPart ||
+	    extent.ExtentLength.QuadPart != partition.PartitionLength.QuadPart ||
+	    volume_length.Length.QuadPart != partition.PartitionLength.QuadPart) {
+		windows_device_set_error(error, error_size, path,
+		    "Windows did not expose the requested enlarged partition geometry");
+		goto out;
+	}
+	device->block_device.sector_count = requested_length / sector_size;
+	result = 0;
+
+out:
+	free(layout);
+	(void)CloseHandle(disk);
+	return result;
+}

--- a/tests/cli/CMakeLists.txt
+++ b/tests/cli/CMakeLists.txt
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: MIT
 
 function(exfat_resize_add_device_test target source test_name)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        set(device_source ${PROJECT_SOURCE_DIR}/src/windows/device.c)
+    else()
+        set(device_source ${PROJECT_SOURCE_DIR}/src/posix/device.c)
+    endif()
     add_executable(
         ${target}
         ${source}
-        ${PROJECT_SOURCE_DIR}/src/device.c
+        ${device_source}
     )
 
     target_include_directories(
@@ -28,6 +33,27 @@ function(exfat_resize_add_device_test target source test_name)
     )
     set_tests_properties(${test_name} PROPERTIES LABELS cli)
 endfunction()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    exfat_resize_add_device_test(
+        exfat_resize_device_image_test
+        device-image-windows.c
+        cli.device-image
+    )
+
+    foreach(test_case help recovery-guidance)
+        add_test(
+            NAME cli.${test_case}
+            COMMAND
+                ${CMAKE_COMMAND}
+                "-DPROGRAM=$<TARGET_FILE:exfat-resize>"
+                "-DTEST_CASE=${test_case}"
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/windows-command-test.cmake"
+        )
+        set_tests_properties(cli.${test_case} PROPERTIES LABELS cli)
+    endforeach()
+    return()
+endif()
 
 exfat_resize_add_device_test(
     exfat_resize_device_bounds_test

--- a/tests/cli/CMakeLists.txt
+++ b/tests/cli/CMakeLists.txt
@@ -2,7 +2,11 @@
 
 function(exfat_resize_add_device_test target source test_name)
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-        set(device_source ${PROJECT_SOURCE_DIR}/src/windows/device.c)
+        set(
+            device_source
+            ${PROJECT_SOURCE_DIR}/src/windows/device.c
+            ${PROJECT_SOURCE_DIR}/src/windows/device_path.c
+        )
     else()
         set(device_source ${PROJECT_SOURCE_DIR}/src/posix/device.c)
     endif()
@@ -35,6 +39,23 @@ function(exfat_resize_add_device_test target source test_name)
 endfunction()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    add_executable(
+        exfat_resize_windows_device_path_test
+        windows-device-path.c
+        ${PROJECT_SOURCE_DIR}/src/windows/device_path.c
+    )
+    target_include_directories(
+        exfat_resize_windows_device_path_test
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/src
+    )
+    exfat_resize_configure_target(exfat_resize_windows_device_path_test)
+    add_test(
+        NAME cli.windows-device-path
+        COMMAND exfat_resize_windows_device_path_test
+    )
+    set_tests_properties(cli.windows-device-path PROPERTIES LABELS cli)
+
     exfat_resize_add_device_test(
         exfat_resize_device_image_test
         device-image-windows.c

--- a/tests/cli/device-image-windows.c
+++ b/tests/cli/device-image-windows.c
@@ -27,15 +27,20 @@ static int create_image(wchar_t *path, size_t path_size)
 	}
 	file = CreateFileW(path, GENERIC_READ | GENERIC_WRITE, 0, NULL, TRUNCATE_EXISTING,
 	    FILE_ATTRIBUTE_NORMAL, NULL);
-	if (file == INVALID_HANDLE_VALUE)
+	if (file == INVALID_HANDLE_VALUE) {
+		(void)DeleteFileW(path);
 		return -1;
+	}
 	size.QuadPart = 4096;
 	if (!SetFilePointerEx(file, size, NULL, FILE_BEGIN) || !SetEndOfFile(file)) {
 		(void)CloseHandle(file);
+		(void)DeleteFileW(path);
 		return -1;
 	}
-	if (!CloseHandle(file))
+	if (!CloseHandle(file)) {
+		(void)DeleteFileW(path);
 		return -1;
+	}
 	return 0;
 }
 

--- a/tests/cli/device-image-windows.c
+++ b/tests/cli/device-image-windows.c
@@ -131,7 +131,7 @@ static int expect_unsupported_path(const char *path)
 		device_close(&device);
 		return -1;
 	}
-	if (strstr(error, "not supported yet") == NULL) {
+	if (strstr(error, "unsupported Windows device path") == NULL) {
 		fprintf(stderr, "unexpected path-rejection diagnostic: %s\n", error);
 		return -1;
 	}
@@ -229,10 +229,8 @@ int main(void)
 	}
 	if (check_io_diagnostics(path) != 0)
 		goto cleanup;
-	if (expect_unsupported_path("E:") != 0 ||
-	    expect_unsupported_path("\\\\.\\PhysicalDrive0") != 0 ||
-	    expect_unsupported_path("//./PhysicalDrive0") != 0 ||
-	    expect_unsupported_path("\\\\?\\Volume{00000000-0000-0000-0000-000000000000}\\") != 0)
+	if (expect_unsupported_path("\\\\.\\PhysicalDrive0") != 0 ||
+	    expect_unsupported_path("//./PhysicalDrive0") != 0)
 		goto cleanup;
 
 	status = EXIT_SUCCESS;

--- a/tests/cli/device-image-windows.c
+++ b/tests/cli/device-image-windows.c
@@ -1,0 +1,247 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "device.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+
+static int create_image(wchar_t *path, size_t path_size)
+{
+	wchar_t directory[MAX_PATH];
+	wchar_t original_path[MAX_PATH];
+	LARGE_INTEGER size;
+	HANDLE file;
+	DWORD directory_length;
+
+	directory_length = GetTempPathW(MAX_PATH, directory);
+	if (path_size < MAX_PATH || directory_length == 0 || directory_length >= MAX_PATH ||
+	    GetTempFileNameW(directory, L"exr", 0, path) == 0)
+		return -1;
+	(void)wcscpy(original_path, path);
+	path[directory_length] = L'\u03a9';
+	if (!MoveFileW(original_path, path)) {
+		(void)DeleteFileW(original_path);
+		return -1;
+	}
+	file = CreateFileW(path, GENERIC_READ | GENERIC_WRITE, 0, NULL, TRUNCATE_EXISTING,
+	    FILE_ATTRIBUTE_NORMAL, NULL);
+	if (file == INVALID_HANDLE_VALUE)
+		return -1;
+	size.QuadPart = 4096;
+	if (!SetFilePointerEx(file, size, NULL, FILE_BEGIN) || !SetEndOfFile(file)) {
+		(void)CloseHandle(file);
+		return -1;
+	}
+	if (!CloseHandle(file))
+		return -1;
+	return 0;
+}
+
+static int wide_to_utf8(const wchar_t *wide, char *utf8, size_t utf8_size)
+{
+	int required;
+
+	required = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wide, -1, NULL, 0, NULL, NULL);
+	if (required == 0 || (size_t)required > utf8_size)
+		return -1;
+	if (WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wide, -1, utf8, required, NULL, NULL) ==
+	    0)
+		return -1;
+	return 0;
+}
+
+static int open_with_closed_handle(struct device *device, const char *path)
+{
+	char error[512];
+
+	device_init(device);
+	if (device_open(device, path, error, sizeof(error)) != 0) {
+		fprintf(stderr, "device_open: %s\n", error);
+		return -1;
+	}
+	if (!CloseHandle(device->handle)) {
+		fprintf(stderr, "cannot invalidate the test image handle\n");
+		device_close(device);
+		return -1;
+	}
+	device->handle = INVALID_HANDLE_VALUE;
+	return 0;
+}
+
+static int check_error(
+    const struct device *device, const char *expected_operation, DWORD expected_number)
+{
+	char formatted_error[256];
+
+	if (device->io_error_operation == NULL ||
+	    strcmp(device->io_error_operation, expected_operation) != 0 ||
+	    device->io_error_number != expected_number) {
+		fprintf(stderr, "wrong I/O diagnostic for %s failure\n", expected_operation);
+		return -1;
+	}
+	device_format_io_error(device, formatted_error, sizeof(formatted_error));
+	if (formatted_error[0] == '\0') {
+		fprintf(stderr, "empty formatted I/O diagnostic\n");
+		return -1;
+	}
+	return 0;
+}
+
+static int check_io_diagnostics(const char *path)
+{
+	unsigned char sector[512] = { 0 };
+	struct device device;
+
+	if (open_with_closed_handle(&device, path) != 0)
+		return -1;
+	if (device.block_device.read(device.block_device.context, 0, 1, sector) == 0 ||
+	    check_error(&device, "read", ERROR_INVALID_HANDLE) != 0)
+		return -1;
+	if (device.block_device.write(device.block_device.context, 0, 1, sector) == 0 ||
+	    check_error(&device, "read", ERROR_INVALID_HANDLE) != 0) {
+		fprintf(stderr, "a later failure replaced the first I/O diagnostic\n");
+		return -1;
+	}
+
+	if (open_with_closed_handle(&device, path) != 0)
+		return -1;
+	if (device.block_device.write(device.block_device.context, 0, 1, sector) == 0 ||
+	    check_error(&device, "write", ERROR_INVALID_HANDLE) != 0)
+		return -1;
+
+	if (open_with_closed_handle(&device, path) != 0)
+		return -1;
+	if (device.block_device.sync(device.block_device.context) == 0 ||
+	    check_error(&device, "synchronize", ERROR_INVALID_HANDLE) != 0)
+		return -1;
+
+	return 0;
+}
+
+static int expect_unsupported_path(const char *path)
+{
+	struct device device;
+	char error[512];
+
+	device_init(&device);
+	if (device_open(&device, path, error, sizeof(error)) == 0) {
+		fprintf(stderr, "unsupported path was opened: %s\n", path);
+		device_close(&device);
+		return -1;
+	}
+	if (strstr(error, "not supported yet") == NULL) {
+		fprintf(stderr, "unexpected path-rejection diagnostic: %s\n", error);
+		return -1;
+	}
+	return 0;
+}
+
+static int check_image_size(const wchar_t *path)
+{
+	LARGE_INTEGER size;
+	HANDLE file = CreateFileW(path, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+	    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+	if (file == INVALID_HANDLE_VALUE)
+		return -1;
+	if (!GetFileSizeEx(file, &size)) {
+		(void)CloseHandle(file);
+		return -1;
+	}
+	(void)CloseHandle(file);
+	return size.QuadPart == 4096 ? 0 : -1;
+}
+
+int main(void)
+{
+	wchar_t wide_path[MAX_PATH];
+	char path[MAX_PATH * 4];
+	char error[512];
+	unsigned char buffer[1024];
+	struct device device;
+	HANDLE competing;
+	size_t index;
+	int status = EXIT_FAILURE;
+
+	device_init(&device);
+	if (create_image(wide_path, sizeof(wide_path) / sizeof(wide_path[0])) != 0) {
+		fwprintf(stderr, L"cannot create test image: Windows error %lu\n",
+		    (unsigned long)GetLastError());
+		return EXIT_FAILURE;
+	}
+	if (wide_to_utf8(wide_path, path, sizeof(path)) != 0) {
+		fprintf(stderr, "cannot convert the test image path to UTF-8\n");
+		goto cleanup;
+	}
+	if (device_open(&device, path, error, sizeof(error)) != 0) {
+		fprintf(stderr, "device_open: %s\n", error);
+		goto cleanup;
+	}
+	if (device.block_device.sector_size != 512 || device.block_device.sector_count != 8) {
+		fprintf(stderr, "wrong image geometry\n");
+		goto close_device;
+	}
+
+	competing =
+	    CreateFileW(wide_path, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+	        NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (competing != INVALID_HANDLE_VALUE || GetLastError() != ERROR_SHARING_VIOLATION) {
+		fprintf(stderr, "image was not held with exclusive sharing\n");
+		if (competing != INVALID_HANDLE_VALUE)
+			(void)CloseHandle(competing);
+		goto close_device;
+	}
+
+	memset(buffer, 0xa5, sizeof(buffer));
+	if (device.block_device.write(device.block_device.context, 7, 1, buffer) != 0 ||
+	    device.block_device.sync(device.block_device.context) != 0) {
+		fprintf(stderr, "in-range write or synchronization failed\n");
+		goto close_device;
+	}
+	memset(buffer, 0, sizeof(buffer));
+	buffer[512] = 0x5a;
+	if (device.block_device.read(device.block_device.context, 7, 1, buffer) != 0) {
+		fprintf(stderr, "last in-range sector was rejected\n");
+		goto close_device;
+	}
+	for (index = 0; index < 512; ++index) {
+		if (buffer[index] != 0xa5) {
+			fprintf(stderr, "read did not complete the requested transfer\n");
+			goto close_device;
+		}
+	}
+	if (buffer[512] != 0x5a) {
+		fprintf(stderr, "read modified bytes beyond the requested transfer\n");
+		goto close_device;
+	}
+	if (device.block_device.write(device.block_device.context, 7, 2, buffer) == 0 ||
+	    device.block_device.read(device.block_device.context, 7, 2, buffer) == 0) {
+		fprintf(stderr, "out-of-range transfer was accepted\n");
+		goto close_device;
+	}
+
+	device_close(&device);
+	if (check_image_size(wide_path) != 0) {
+		fprintf(stderr, "out-of-range write changed the image size\n");
+		goto cleanup;
+	}
+	if (check_io_diagnostics(path) != 0)
+		goto cleanup;
+	if (expect_unsupported_path("E:") != 0 ||
+	    expect_unsupported_path("\\\\.\\PhysicalDrive0") != 0 ||
+	    expect_unsupported_path("//./PhysicalDrive0") != 0 ||
+	    expect_unsupported_path("\\\\?\\Volume{00000000-0000-0000-0000-000000000000}\\") != 0)
+		goto cleanup;
+
+	status = EXIT_SUCCESS;
+	printf("device-image: passed\n");
+	goto cleanup;
+
+close_device:
+	device_close(&device);
+cleanup:
+	(void)DeleteFileW(wide_path);
+	return status;
+}

--- a/tests/cli/prepare-windows-volume.sh
+++ b/tests/cli/prepare-windows-volume.sh
@@ -34,10 +34,8 @@ done
 total_sectors=393216
 partition_start=2048
 initial_sectors=196608
-target_sectors=327680
 initial_end=$((partition_start + initial_sectors - 1))
-target_end=$((partition_start + target_sectors - 1))
-target_bytes=$((target_sectors * 512))
+initial_bytes=$((initial_sectors * 512))
 
 mkdir -p "$mountpoint"
 truncate -s "$((total_sectors * 512))" "$raw"
@@ -83,20 +81,11 @@ sync
 sudo umount "$mountpoint"
 test_mount=
 sudo fsck.exfat -n "$partition"
-detach_raw_disk
-
-sgdisk --delete=1 \
-	--new="1:${partition_start}:${target_end}" \
-	--typecode=1:0700 \
-	--change-name=1:EXRTEST "$raw" >/dev/null
-
-attach_raw_disk
 actual_bytes=$(sudo blockdev --getsize64 "$partition")
-if [ "$actual_bytes" -ne "$target_bytes" ]; then
-	echo "wrong enlarged partition size: $actual_bytes, expected $target_bytes" >&2
+if [ "$actual_bytes" -ne "$initial_bytes" ]; then
+	echo "wrong initial partition size: $actual_bytes, expected $initial_bytes" >&2
 	exit 1
 fi
-sudo fsck.exfat -n "$partition"
 sudo mount.exfat-fuse -o "uid=$(id -u),gid=$(id -g),ro" "$partition" "$mountpoint"
 test_mount=$mountpoint
 actual_hash=$(sha256sum "$mountpoint/payload.bin" | awk '{ print $1 }')

--- a/tests/cli/prepare-windows-volume.sh
+++ b/tests/cli/prepare-windows-volume.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+output=${1:?output directory is required}
+temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-windows-volume.XXXXXX")
+raw=$temporary/prepared.raw
+vhdx=$temporary/prepared.vhdx
+mountpoint=$temporary/mount
+loop_device=
+test_mount=
+
+cleanup() {
+	if [ -n "$test_mount" ]; then
+		sudo umount "$test_mount" >/dev/null 2>&1 || true
+		test_mount=
+	fi
+	if [ -n "$loop_device" ]; then
+		sudo losetup --detach "$loop_device" >/dev/null 2>&1 || true
+		loop_device=
+	fi
+	rm -rf "$temporary"
+}
+trap cleanup EXIT HUP INT TERM
+
+for tool in blockdev fsck.exfat losetup mkfs.exfat mount.exfat-fuse qemu-img sgdisk; do
+	command -v "$tool" >/dev/null || {
+		echo "missing $tool" >&2
+		exit 1
+	}
+done
+
+total_sectors=393216
+partition_start=2048
+initial_sectors=196608
+target_sectors=327680
+initial_end=$((partition_start + initial_sectors - 1))
+target_end=$((partition_start + target_sectors - 1))
+target_bytes=$((target_sectors * 512))
+
+mkdir -p "$mountpoint"
+truncate -s "$((total_sectors * 512))" "$raw"
+sgdisk --clear \
+	--new="1:${partition_start}:${initial_end}" \
+	--typecode=1:0700 \
+	--change-name=1:EXRTEST "$raw" >/dev/null
+
+attach_raw_disk() {
+	loop_device=$(sudo losetup --find --show --partscan "$raw")
+	partition=${loop_device}p1
+	index=0
+	while [ ! -b "$partition" ] && [ "$index" -lt 50 ]; do
+		sleep 0.1
+		index=$((index + 1))
+	done
+	if [ ! -b "$partition" ]; then
+		echo "partition device did not appear: $partition" >&2
+		exit 1
+	fi
+}
+
+detach_raw_disk() {
+	sudo losetup --detach "$loop_device"
+	loop_device=
+}
+
+attach_raw_disk
+sudo mkfs.exfat -c 32768 -L EXRTEST "$partition" >/dev/null
+sudo mount.exfat-fuse -o "uid=$(id -u),gid=$(id -g)" "$partition" "$mountpoint"
+test_mount=$mountpoint
+
+dd if=/dev/urandom of="$mountpoint/payload.bin" bs=1M count=8 status=none
+mkdir "$mountpoint/small-files"
+index=1
+while [ "$index" -le 200 ]; do
+	test_file=$mountpoint/small-files/$index.txt
+	printf 'exfat-resize Windows volume fixture %d\n' "$index" >"$test_file"
+	index=$((index + 1))
+done
+payload_hash=$(sha256sum "$mountpoint/payload.bin" | awk '{ print $1 }')
+sync
+sudo umount "$mountpoint"
+test_mount=
+sudo fsck.exfat -n "$partition"
+detach_raw_disk
+
+sgdisk --delete=1 \
+	--new="1:${partition_start}:${target_end}" \
+	--typecode=1:0700 \
+	--change-name=1:EXRTEST "$raw" >/dev/null
+
+attach_raw_disk
+actual_bytes=$(sudo blockdev --getsize64 "$partition")
+if [ "$actual_bytes" -ne "$target_bytes" ]; then
+	echo "wrong enlarged partition size: $actual_bytes, expected $target_bytes" >&2
+	exit 1
+fi
+sudo fsck.exfat -n "$partition"
+sudo mount.exfat-fuse -o "uid=$(id -u),gid=$(id -g),ro" "$partition" "$mountpoint"
+test_mount=$mountpoint
+actual_hash=$(sha256sum "$mountpoint/payload.bin" | awk '{ print $1 }')
+if [ "$actual_hash" != "$payload_hash" ]; then
+	echo "payload changed while preparing the fixture" >&2
+	exit 1
+fi
+sudo umount "$mountpoint"
+test_mount=
+detach_raw_disk
+
+qemu-img convert -f raw -O vhdx -o subformat=dynamic "$raw" "$vhdx"
+qemu-img check -f vhdx "$vhdx"
+
+mkdir -p "$output"
+cp "$vhdx" "$output/prepared.vhdx"
+printf '%s\n' "$payload_hash" >"$output/payload.sha256"
+printf 'prepare-windows-volume: passed\n'

--- a/tests/cli/recovery-guidance.sh
+++ b/tests/cli/recovery-guidance.sh
@@ -5,7 +5,8 @@ set -eu
 
 program=$1
 temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-guidance.XXXXXX")
-no_write_guidance="exfat-resize: no filesystem write was attempted; correct the error and retry when appropriate"
+no_write_guidance="exfat-resize: no filesystem write was attempted;"
+no_write_guidance="$no_write_guidance correct the error and retry when appropriate"
 
 cleanup() {
 	rm -rf "$temporary"
@@ -54,6 +55,12 @@ trap cleanup EXIT HUP INT TERM
 
 expect_no_write_failure missing-target
 expect_no_write_failure unknown-option --unknown
+expect_no_write_failure grow-partition --grow-partition "$temporary/missing" 1
+if ! grep -F "supported only for logical Windows volumes" \
+	"$temporary/grow-partition.out" >/dev/null; then
+	echo "grow-partition did not report its platform restriction" >&2
+	exit 1
+fi
 expect_no_write_failure invalid-size "$temporary/missing" 0
 expect_no_write_failure target-open "$temporary/missing"
 

--- a/tests/cli/windows-command-test.cmake
+++ b/tests/cli/windows-command-test.cmake
@@ -49,7 +49,7 @@ endfunction()
 if(TEST_CASE STREQUAL "help")
     expect_success(--help)
     foreach(required_text
-            "Usage: exfat-resize IMAGE [SIZE]"
+            "Usage: exfat-resize DEVICE [SIZE]"
             "Arguments:"
             "Desired filesystem size in bytes"
             "Options:"
@@ -59,7 +59,8 @@ if(TEST_CASE STREQUAL "help")
             "Read the safety requirements"
             "README.md distributed with exfat-resize"
             "https://github.com/huven/exfat-resize#safety"
-            "Windows volumes such as E: and volume-GUID paths are not supported yet"
+            "drive letter such as E:"
+            [[Physical-disk paths such as \\.\PhysicalDrive0 are not supported]]
     )
         require_text("${command_output}" "${required_text}")
     endforeach()
@@ -70,8 +71,8 @@ elseif(TEST_CASE STREQUAL "recovery-guidance")
     expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/missing.exfat")
     expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/exfat-resize-Ω-missing.exfat")
     require_text("${command_output}" "exfat-resize-Ω-missing.exfat")
-    expect_no_write_failure("E:")
-    require_text("${command_output}" "Windows volume and device paths are not supported yet")
+    expect_no_write_failure([[\\.\PhysicalDrive0]])
+    require_text("${command_output}" "unsupported Windows device path")
     foreach(option -h --help -V --version)
         expect_success("${option}")
     endforeach()

--- a/tests/cli/windows-command-test.cmake
+++ b/tests/cli/windows-command-test.cmake
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+
+if(NOT DEFINED PROGRAM OR NOT DEFINED TEST_CASE)
+    message(FATAL_ERROR "PROGRAM and TEST_CASE are required")
+endif()
+
+function(require_text output expected)
+    string(FIND "${output}" "${expected}" offset)
+    if(offset EQUAL -1)
+        message(FATAL_ERROR "Command output does not contain '${expected}':\n${output}")
+    endif()
+endfunction()
+
+function(expect_success)
+    execute_process(
+        COMMAND "${PROGRAM}" ${ARGN}
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE error
+    )
+    if(NOT result EQUAL 0)
+        message(FATAL_ERROR "Command failed unexpectedly:\n${output}${error}")
+    endif()
+    set(command_output "${output}${error}" PARENT_SCOPE)
+endfunction()
+
+function(expect_no_write_failure)
+    execute_process(
+        COMMAND "${PROGRAM}" ${ARGN}
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE error
+    )
+    set(combined "${output}${error}")
+    if(result EQUAL 0)
+        message(FATAL_ERROR "Command succeeded unexpectedly:\n${combined}")
+    endif()
+    require_text("${combined}"
+        "exfat-resize: no filesystem write was attempted; correct the error and retry when appropriate"
+    )
+    string(FIND "${combined}" "restore the verified backup" destructive_offset)
+    string(FIND "${combined}" "filesystem checker" checker_offset)
+    if(NOT destructive_offset EQUAL -1 OR NOT checker_offset EQUAL -1)
+        message(FATAL_ERROR "Command reported destructive recovery guidance:\n${combined}")
+    endif()
+    set(command_output "${combined}" PARENT_SCOPE)
+endfunction()
+
+if(TEST_CASE STREQUAL "help")
+    expect_success(--help)
+    foreach(required_text
+            "Usage: exfat-resize IMAGE [SIZE]"
+            "Arguments:"
+            "Desired filesystem size in bytes"
+            "Options:"
+            "Safety:"
+            "Documentation:"
+            "Make and verify a backup"
+            "Read the safety requirements"
+            "README.md distributed with exfat-resize"
+            "https://github.com/huven/exfat-resize#safety"
+            "Windows volumes such as E: and volume-GUID paths are not supported yet"
+    )
+        require_text("${command_output}" "${required_text}")
+    endforeach()
+elseif(TEST_CASE STREQUAL "recovery-guidance")
+    expect_no_write_failure()
+    expect_no_write_failure(--unknown)
+    expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/missing.exfat" 0)
+    expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/missing.exfat")
+    expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/exfat-resize-Ω-missing.exfat")
+    require_text("${command_output}" "exfat-resize-Ω-missing.exfat")
+    expect_no_write_failure("E:")
+    require_text("${command_output}" "Windows volume and device paths are not supported yet")
+    foreach(option -h --help -V --version)
+        expect_success("${option}")
+    endforeach()
+else()
+    message(FATAL_ERROR "Unknown TEST_CASE: ${TEST_CASE}")
+endif()

--- a/tests/cli/windows-command-test.cmake
+++ b/tests/cli/windows-command-test.cmake
@@ -50,6 +50,7 @@ if(TEST_CASE STREQUAL "help")
     expect_success(--help)
     foreach(required_text
             "Usage: exfat-resize DEVICE [SIZE]"
+            "exfat-resize --grow-partition DEVICE SIZE"
             "Arguments:"
             "Desired filesystem size in bytes"
             "Options:"
@@ -60,6 +61,8 @@ if(TEST_CASE STREQUAL "help")
             "README.md distributed with exfat-resize"
             "https://github.com/huven/exfat-resize#safety"
             "drive letter such as E:"
+            "--grow-partition"
+            "Grow a basic partition to explicit SIZE when needed"
             [[Physical-disk paths such as \\.\PhysicalDrive0 are not supported]]
     )
         require_text("${command_output}" "${required_text}")
@@ -67,6 +70,8 @@ if(TEST_CASE STREQUAL "help")
 elseif(TEST_CASE STREQUAL "recovery-guidance")
     expect_no_write_failure()
     expect_no_write_failure(--unknown)
+    expect_no_write_failure(--grow-partition [[E:]])
+    require_text("${command_output}" "--grow-partition requires an explicit SIZE")
     expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/missing.exfat" 0)
     expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/missing.exfat")
     expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/exfat-resize-Ω-missing.exfat")

--- a/tests/cli/windows-device-path.c
+++ b/tests/cli/windows-device-path.c
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "windows/device_path.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct path_case {
+	const char *path;
+	enum windows_device_path_type type;
+	const char *normalized;
+};
+
+static int check_case(const struct path_case *test)
+{
+	char normalized[64];
+	enum windows_device_path_type type = windows_classify_device_path(test->path);
+
+	if (type != test->type) {
+		fprintf(stderr, "wrong classification for %s: got %d, expected %d\n", test->path, (int)type,
+		    (int)test->type);
+		return -1;
+	}
+	if (test->normalized == NULL)
+		return 0;
+	if (windows_normalize_volume_path(test->path, normalized, sizeof(normalized)) != 0 ||
+	    strcmp(normalized, test->normalized) != 0) {
+		fprintf(stderr, "wrong normalized volume path for %s\n", test->path);
+		return -1;
+	}
+	return 0;
+}
+
+int main(void)
+{
+	static const struct path_case cases[] = {
+		{ "E:", WINDOWS_DEVICE_PATH_VOLUME, "\\\\.\\E:" },
+		{ "e:", WINDOWS_DEVICE_PATH_VOLUME, "\\\\.\\e:" },
+		{ "\\\\.\\E:", WINDOWS_DEVICE_PATH_VOLUME, "\\\\.\\E:" },
+		{ "//./e:", WINDOWS_DEVICE_PATH_VOLUME, "\\\\.\\e:" },
+		{ "\\\\?\\Volume{01234567-89ab-cdef-0123-456789abcdef}", WINDOWS_DEVICE_PATH_VOLUME,
+		    "\\\\?\\Volume{01234567-89ab-cdef-0123-456789abcdef}" },
+		{ "\\\\?\\Volume{01234567-89AB-CDEF-0123-456789ABCDEF}\\", WINDOWS_DEVICE_PATH_VOLUME,
+		    "\\\\?\\Volume{01234567-89AB-CDEF-0123-456789ABCDEF}" },
+		{ "image.exfat", WINDOWS_DEVICE_PATH_IMAGE, NULL },
+		{ "E:\\images\\image.exfat", WINDOWS_DEVICE_PATH_IMAGE, NULL },
+		{ "\\\\server\\share\\image.exfat", WINDOWS_DEVICE_PATH_IMAGE, NULL },
+		{ "\\\\?\\C:\\long\\image.exfat", WINDOWS_DEVICE_PATH_IMAGE, NULL },
+		{ "\\\\?\\UNC\\server\\share\\image.exfat", WINDOWS_DEVICE_PATH_IMAGE, NULL },
+		{ "\\\\.\\PhysicalDrive0", WINDOWS_DEVICE_PATH_UNSUPPORTED, NULL },
+		{ "//./PhysicalDrive0", WINDOWS_DEVICE_PATH_UNSUPPORTED, NULL },
+		{ "\\\\?\\GLOBALROOT\\Device\\Harddisk0", WINDOWS_DEVICE_PATH_UNSUPPORTED, NULL },
+		{ "\\\\?\\Volume{01234567-89ab-cdef-0123-456789abcdef}\\image.exfat",
+		    WINDOWS_DEVICE_PATH_UNSUPPORTED, NULL },
+		{ "\\\\?\\Volume{not-a-guid}\\", WINDOWS_DEVICE_PATH_UNSUPPORTED, NULL },
+		{ "\\\\.\\E:\\", WINDOWS_DEVICE_PATH_UNSUPPORTED, NULL },
+	};
+	char normalized[6];
+	size_t index;
+
+	for (index = 0; index < sizeof(cases) / sizeof(cases[0]); ++index) {
+		if (check_case(&cases[index]) != 0)
+			return EXIT_FAILURE;
+	}
+	if (windows_normalize_volume_path("image.exfat", normalized, sizeof(normalized)) == 0 ||
+	    windows_normalize_volume_path("E:", normalized, sizeof(normalized)) == 0) {
+		fprintf(stderr, "invalid volume normalization succeeded\n");
+		return EXIT_FAILURE;
+	}
+	printf("windows-device-path: passed\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/cli/windows-volume.ps1
+++ b/tests/cli/windows-volume.ps1
@@ -89,8 +89,14 @@ function Test-VolumeTarget {
             "Volume $DriveLetter`: is not exFAT"
         Assert-Condition ($Partition.Size -eq 160MB) `
             "Partition size is $($Partition.Size), expected 160 MiB"
-        Assert-Condition ($Volume.Size -eq 96MB) `
-            "Initial filesystem size is $($Volume.Size), expected 96 MiB"
+        # Get-Volume.Size is usable cluster capacity, not the exFAT VolumeLength.
+        $InitialFileSystemSize = [uint64] $Volume.Size
+        Assert-Condition (
+            $InitialFileSystemSize -ge 90MB -and $InitialFileSystemSize -le 100MB
+        ) "Initial usable filesystem capacity is $InitialFileSystemSize, expected about 94 MiB"
+        Assert-Condition (($Partition.Size - $InitialFileSystemSize) -ge 60MB) `
+            "Initial filesystem does not leave enough room to test growth"
+        Write-Host "Initial usable filesystem capacity: $InitialFileSystemSize bytes"
 
         $ActualHash = (Get-FileHash "$DriveLetter`:\payload.bin" -Algorithm SHA256).Hash
         Assert-Condition ($ActualHash -eq $PayloadHash) "Initial payload hash differs"
@@ -113,8 +119,14 @@ function Test-VolumeTarget {
         $Volume = Wait-Volume $DriveLetter
         Invoke-CleanCheck $DriveLetter
         $Volume = Wait-Volume $DriveLetter
-        Assert-Condition ($Volume.Size -eq $Partition.Size) `
-            "Filesystem size $($Volume.Size) does not match partition size $($Partition.Size)"
+        $FinalFileSystemSize = [uint64] $Volume.Size
+        Write-Host "Final usable filesystem capacity: $FinalFileSystemSize bytes"
+        Assert-Condition ($FinalFileSystemSize -ge ($InitialFileSystemSize + 60MB)) `
+            "Filesystem capacity grew by less than 60 MiB"
+        Assert-Condition ($FinalFileSystemSize -le $Partition.Size) `
+            "Filesystem capacity exceeds partition size"
+        Assert-Condition (($Partition.Size - $FinalFileSystemSize) -le 4MB) `
+            "Filesystem leaves more than 4 MiB of the partition unavailable"
 
         $ActualHash = (Get-FileHash "$DriveLetter`:\payload.bin" -Algorithm SHA256).Hash
         Assert-Condition ($ActualHash -eq $PayloadHash) `
@@ -127,7 +139,8 @@ function Test-VolumeTarget {
     finally {
         Set-Location $env:GITHUB_WORKSPACE
         if ($Mounted) {
-            Dismount-DiskImage -ImagePath $ImagePath -StorageType VHDX -ErrorAction Continue
+            Dismount-DiskImage -ImagePath $ImagePath -StorageType VHDX -ErrorAction Continue |
+                Out-Null
         }
     }
 }

--- a/tests/cli/windows-volume.ps1
+++ b/tests/cli/windows-volume.ps1
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: MIT
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Program,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Fixture,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ExpectedHash
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-Condition {
+    param(
+        [bool] $Condition,
+        [string] $Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Wait-Volume {
+    param([char] $DriveLetter)
+
+    for ($Index = 0; $Index -lt 50; $Index++) {
+        Get-Item "$DriveLetter`:\" -ErrorAction SilentlyContinue | Out-Null
+        $Volume = Get-Volume -DriveLetter $DriveLetter -ErrorAction SilentlyContinue
+        if ($null -ne $Volume -and $Volume.OperationalStatus -contains "OK") {
+            return $Volume
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    throw "Volume $DriveLetter`: did not become ready"
+}
+
+function Invoke-CleanCheck {
+    param([char] $DriveLetter)
+
+    & chkdsk.exe "$DriveLetter`:" /F /X
+    Assert-Condition ($LASTEXITCODE -eq 0) `
+        "chkdsk reported errors for volume $DriveLetter`: (exit $LASTEXITCODE)"
+}
+
+function Invoke-Resize {
+    param([string] $Target)
+
+    $Output = & $Program $Target 2>&1
+    $Status = $LASTEXITCODE
+    $Output | ForEach-Object { Write-Host $_ }
+    Assert-Condition ($Status -eq 0) "exfat-resize failed for $Target (exit $Status)"
+    Assert-Condition (($Output -join "`n") -match "exfat-resize: resized") `
+        "exfat-resize did not report success for $Target"
+}
+
+function Test-VolumeTarget {
+    param(
+        [string] $ImagePath,
+        [ValidateSet("DriveLetter", "VolumeGuid")]
+        [string] $TargetType,
+        [string] $PayloadHash
+    )
+
+    $Mounted = $false
+    try {
+        $DiskImage = Mount-DiskImage `
+            -ImagePath $ImagePath -StorageType VHDX -Access ReadWrite -PassThru
+        $Mounted = $true
+        $Disk = $DiskImage | Get-Disk
+        $Partitions = @(Get-Partition -DiskNumber $Disk.Number |
+            Where-Object { $_.Type -ne "Reserved" })
+        Assert-Condition ($Partitions.Count -eq 1) `
+            "Expected one data partition on disk $($Disk.Number), got $($Partitions.Count)"
+        $Partition = $Partitions[0]
+        if ([string]::IsNullOrWhiteSpace([string] $Partition.DriveLetter)) {
+            $Partition | Add-PartitionAccessPath -AssignDriveLetter
+            $Partition = Get-Partition -DiskNumber $Disk.Number `
+                -PartitionNumber $Partition.PartitionNumber
+        }
+
+        $DriveLetter = [char] $Partition.DriveLetter
+        $Volume = Wait-Volume $DriveLetter
+        Assert-Condition ($Volume.FileSystem -eq "exFAT") `
+            "Volume $DriveLetter`: is not exFAT"
+        Assert-Condition ($Partition.Size -eq 160MB) `
+            "Partition size is $($Partition.Size), expected 160 MiB"
+        Assert-Condition ($Volume.Size -eq 96MB) `
+            "Initial filesystem size is $($Volume.Size), expected 96 MiB"
+
+        $ActualHash = (Get-FileHash "$DriveLetter`:\payload.bin" -Algorithm SHA256).Hash
+        Assert-Condition ($ActualHash -eq $PayloadHash) "Initial payload hash differs"
+        Assert-Condition (
+            @(Get-ChildItem "$DriveLetter`:\small-files" -File).Count -eq 200
+        ) "Initial small-file count differs"
+
+        if ($TargetType -eq "DriveLetter") {
+            $Target = "$DriveLetter`:"
+        } else {
+            $Target = ((& mountvol.exe "$DriveLetter`:" /L) |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                Select-Object -First 1).Trim()
+            Assert-Condition ($Target -match '^\\\\\?\\Volume\{[0-9A-Fa-f-]+\}\\$') `
+                "mountvol returned an unexpected volume name: $Target"
+        }
+
+        Set-Location $env:GITHUB_WORKSPACE
+        Invoke-Resize $Target
+        $Volume = Wait-Volume $DriveLetter
+        Invoke-CleanCheck $DriveLetter
+        $Volume = Wait-Volume $DriveLetter
+        Assert-Condition ($Volume.Size -eq $Partition.Size) `
+            "Filesystem size $($Volume.Size) does not match partition size $($Partition.Size)"
+
+        $ActualHash = (Get-FileHash "$DriveLetter`:\payload.bin" -Algorithm SHA256).Hash
+        Assert-Condition ($ActualHash -eq $PayloadHash) `
+            "Payload hash differs after resizing through $TargetType"
+        Assert-Condition (
+            @(Get-ChildItem "$DriveLetter`:\small-files" -File).Count -eq 200
+        ) "Small-file count differs after resizing through $TargetType"
+        Write-Host "windows-volume ($TargetType): passed"
+    }
+    finally {
+        Set-Location $env:GITHUB_WORKSPACE
+        if ($Mounted) {
+            Dismount-DiskImage -ImagePath $ImagePath -StorageType VHDX -ErrorAction Continue
+        }
+    }
+}
+
+$Program = (Resolve-Path -LiteralPath $Program).Path
+$Fixture = (Resolve-Path -LiteralPath $Fixture).Path
+$PayloadHash = (Get-Content -LiteralPath $ExpectedHash -Raw).Trim().ToUpperInvariant()
+$Temporary = Join-Path $env:RUNNER_TEMP "exfat-resize-windows-volume"
+New-Item -ItemType Directory -Path $Temporary -Force | Out-Null
+
+$DriveImage = Join-Path $Temporary "drive-letter.vhdx"
+$GuidImage = Join-Path $Temporary "volume-guid.vhdx"
+Copy-Item -LiteralPath $Fixture -Destination $DriveImage -Force
+Copy-Item -LiteralPath $Fixture -Destination $GuidImage -Force
+
+Test-VolumeTarget $DriveImage DriveLetter $PayloadHash
+Test-VolumeTarget $GuidImage VolumeGuid $PayloadHash
+Write-Host "windows-volume: passed"

--- a/tests/cli/windows-volume.ps1
+++ b/tests/cli/windows-volume.ps1
@@ -76,6 +76,8 @@ function Invoke-ExpectedFailure {
         "exfat-resize unexpectedly succeeded with arguments: $Arguments"
     Assert-Condition (($Output -join "`n") -match [regex]::Escape($ExpectedText)) `
         "exfat-resize did not report '$ExpectedText'"
+    Assert-Condition (($Output -join "`n") -notmatch 'exfat-resize: [A-Za-z]::') `
+        "exfat-resize printed duplicate punctuation after a drive designator"
 }
 
 function Test-VolumeTarget {
@@ -146,6 +148,16 @@ function Test-VolumeTarget {
             "Partition changed without --grow-partition"
 
         if ($TargetType -eq "DriveLetter") {
+            Invoke-ExpectedFailure `
+                -Arguments @(
+                    "--grow-partition", $Target, [string] ([uint64] ($Partition.Size + 1))
+                ) `
+                -ExpectedText "target does not add enough usable clusters"
+            $Partition = Get-Partition -DiskNumber $Disk.Number `
+                -PartitionNumber $Partition.PartitionNumber
+            Assert-Condition ($Partition.Size -eq 96MB) `
+                "Partition changed for a target that cannot grow the filesystem"
+
             Invoke-ExpectedFailure `
                 -Arguments @("--grow-partition", $Target, [string] ([uint64] 256MB)) `
                 -ExpectedText "not enough immediately trailing unallocated space"

--- a/tests/cli/windows-volume.ps1
+++ b/tests/cli/windows-volume.ps1
@@ -48,14 +48,34 @@ function Invoke-CleanCheck {
 }
 
 function Invoke-Resize {
-    param([string] $Target)
+    param(
+        [string] $Target,
+        [uint64] $TargetSize
+    )
 
-    $Output = & $Program $Target 2>&1
+    $Output = & $Program --grow-partition $Target $TargetSize 2>&1
     $Status = $LASTEXITCODE
     $Output | ForEach-Object { Write-Host $_ }
     Assert-Condition ($Status -eq 0) "exfat-resize failed for $Target (exit $Status)"
     Assert-Condition (($Output -join "`n") -match "exfat-resize: resized") `
         "exfat-resize did not report success for $Target"
+    Assert-Condition (($Output -join "`n") -match "grew the partition") `
+        "exfat-resize did not report partition growth for $Target"
+}
+
+function Invoke-ExpectedFailure {
+    param(
+        [string[]] $Arguments,
+        [string] $ExpectedText
+    )
+
+    $Output = & $Program @Arguments 2>&1
+    $Status = $LASTEXITCODE
+    $Output | ForEach-Object { Write-Host $_ }
+    Assert-Condition ($Status -ne 0) `
+        "exfat-resize unexpectedly succeeded with arguments: $Arguments"
+    Assert-Condition (($Output -join "`n") -match [regex]::Escape($ExpectedText)) `
+        "exfat-resize did not report '$ExpectedText'"
 }
 
 function Test-VolumeTarget {
@@ -87,15 +107,15 @@ function Test-VolumeTarget {
         $Volume = Wait-Volume $DriveLetter
         Assert-Condition ($Volume.FileSystem -eq "exFAT") `
             "Volume $DriveLetter`: is not exFAT"
-        Assert-Condition ($Partition.Size -eq 160MB) `
-            "Partition size is $($Partition.Size), expected 160 MiB"
+        Assert-Condition ($Partition.Size -eq 96MB) `
+            "Partition size is $($Partition.Size), expected 96 MiB"
         # Get-Volume.Size is usable cluster capacity, not the exFAT VolumeLength.
         $InitialFileSystemSize = [uint64] $Volume.Size
         Assert-Condition (
             $InitialFileSystemSize -ge 90MB -and $InitialFileSystemSize -le 100MB
         ) "Initial usable filesystem capacity is $InitialFileSystemSize, expected about 94 MiB"
-        Assert-Condition (($Partition.Size - $InitialFileSystemSize) -ge 60MB) `
-            "Initial filesystem does not leave enough room to test growth"
+        Assert-Condition (($Disk.Size - $Partition.Offset - $Partition.Size) -ge 60MB) `
+            "Disk does not leave enough trailing space to test partition growth"
         Write-Host "Initial usable filesystem capacity: $InitialFileSystemSize bytes"
 
         $ActualHash = (Get-FileHash "$DriveLetter`:\payload.bin" -Algorithm SHA256).Hash
@@ -115,7 +135,33 @@ function Test-VolumeTarget {
         }
 
         Set-Location $env:GITHUB_WORKSPACE
-        Invoke-Resize $Target
+        $TargetSize = [uint64] 160MB
+        Invoke-ExpectedFailure `
+            -Arguments @($Target, [string] $TargetSize) `
+            -ExpectedText "request is outside the backing device"
+        $Volume = Wait-Volume $DriveLetter
+        $Partition = Get-Partition -DiskNumber $Disk.Number `
+            -PartitionNumber $Partition.PartitionNumber
+        Assert-Condition ($Partition.Size -eq 96MB) `
+            "Partition changed without --grow-partition"
+
+        if ($TargetType -eq "DriveLetter") {
+            Invoke-ExpectedFailure `
+                -Arguments @("--grow-partition", $Target, [string] ([uint64] 256MB)) `
+                -ExpectedText "not enough immediately trailing unallocated space"
+            $Volume = Wait-Volume $DriveLetter
+            $Partition = Get-Partition -DiskNumber $Disk.Number `
+                -PartitionNumber $Partition.PartitionNumber
+            Assert-Condition ($Partition.Size -eq 96MB) `
+                "Partition changed after an out-of-space failure"
+        }
+
+        Invoke-Resize $Target $TargetSize
+        Update-HostStorageCache
+        $Partition = Get-Partition -DiskNumber $Disk.Number `
+            -PartitionNumber $Partition.PartitionNumber
+        Assert-Condition ($Partition.Size -eq $TargetSize) `
+            "Partition size is $($Partition.Size), expected $TargetSize"
         $Volume = Wait-Volume $DriveLetter
         Invoke-CleanCheck $DriveLetter
         $Volume = Wait-Volume $DriveLetter

--- a/tests/package/CMakeLists.txt
+++ b/tests/package/CMakeLists.txt
@@ -8,9 +8,16 @@ configure_file(
 
 add_test(
     NAME package.install-documentation
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/install_test.cmake
+    COMMAND
+        ${CMAKE_COMMAND}
+        "-DINSTALL_CONFIG=$<CONFIG>"
+        -P ${CMAKE_CURRENT_BINARY_DIR}/install_test.cmake
 )
-set_tests_properties(package.install-documentation PROPERTIES LABELS package)
+set_tests_properties(
+    package.install-documentation
+    PROPERTIES
+        LABELS "package;package-native"
+)
 
 add_test(
     NAME package.version
@@ -20,7 +27,11 @@ add_test(
         -DEXFAT_RESIZE_VERSION_TEST_DIR=${CMAKE_CURRENT_BINARY_DIR}/version-test
         -P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
 )
-set_tests_properties(package.version PROPERTIES LABELS package)
+set_tests_properties(
+    package.version
+    PROPERTIES
+        LABELS "package;package-native"
+)
 
 add_test(
     NAME package.release-check

--- a/tests/package/install_test.cmake.in
+++ b/tests/package/install_test.cmake.in
@@ -23,9 +23,14 @@ set(license "${documentation_dir}/LICENSE")
 set(transaction_document "${documentation_dir}/docs/TRANSACTION.md")
 
 file(REMOVE_RECURSE "${install_prefix}")
+set(install_command
+    "@CMAKE_COMMAND@" --install "@PROJECT_BINARY_DIR@" --prefix "${install_prefix}"
+)
+if(DEFINED INSTALL_CONFIG AND NOT INSTALL_CONFIG STREQUAL "")
+    list(APPEND install_command --config "${INSTALL_CONFIG}")
+endif()
 execute_process(
-    COMMAND
-        "@CMAKE_COMMAND@" --install "@PROJECT_BINARY_DIR@" --prefix "${install_prefix}"
+    COMMAND ${install_command}
     RESULT_VARIABLE
         install_result
     OUTPUT_VARIABLE
@@ -51,11 +56,9 @@ foreach(required_file
 endforeach()
 
 if("@EXFAT_RESIZE_BUILD_CLI@")
-    foreach(required_cli_file "${installed_cli}" "${installed_manpage}")
-        if(NOT EXISTS "${required_cli_file}")
-            message(FATAL_ERROR "Installed CLI file not found at ${required_cli_file}")
-        endif()
-    endforeach()
+    if(NOT EXISTS "${installed_cli}")
+        message(FATAL_ERROR "Installed CLI file not found at ${installed_cli}")
+    endif()
     execute_process(
         COMMAND "${installed_cli}" --version
         RESULT_VARIABLE cli_result
@@ -68,6 +71,12 @@ if("@EXFAT_RESIZE_BUILD_CLI@")
         message(FATAL_ERROR
             "Installed CLI version check failed:\n${cli_output}${cli_error}"
         )
+    endif()
+endif()
+
+if("@EXFAT_RESIZE_INSTALL_MANPAGE@")
+    if(NOT EXISTS "${installed_manpage}")
+        message(FATAL_ERROR "Installed manual page not found at ${installed_manpage}")
     endif()
     file(READ "${installed_manpage}" manpage_contents)
     foreach(required_text

--- a/tests/package/os_detection.cmake.in
+++ b/tests/package/os_detection.cmake.in
@@ -77,6 +77,7 @@ execute_process(
 if(result EQUAL 0)
     message(FATAL_ERROR "The iOS CLI configuration unexpectedly succeeded")
 endif()
-if(NOT "${output}${error}" MATCHES "The exfat-resize CLI supports only macOS and Linux")
+if(NOT "${output}${error}" MATCHES
+   "The exfat-resize CLI supports only macOS, Linux, and Windows")
     message(FATAL_ERROR "The iOS CLI configuration produced an unexpected error:\n${output}${error}")
 endif()


### PR DESCRIPTION
Add a native Windows build of the `exfat-resize` CLI while retaining the existing
macOS and Linux behavior.

This PR:

- Refactors the CLI into shared command handling with platform-specific entry
  points and device backends.
- Adds native Windows support for regular image files.
- Adds access to logical Windows volumes through drive designators such as `E:`
  and volume-GUID paths.
- Adds opt-in partition growth through `--grow-partition`.
- Builds the CLI by default in top-level Windows builds.
- Extends CI and documentation for the new Windows functionality.

No behavioral change is intended for the existing macOS and Linux CLI.

## Windows usage

Resize an image file or grow a filesystem to the existing size of a logical
volume:

```text
exfat-resize image.exfat
exfat-resize E:
exfat-resize \\?\Volume{GUID}\
```

Resize to an explicit size:

```text
exfat-resize E: 549755813888
```

If the requested size does not fit in the current partition, opt in to growing
the containing partition first:

```text
exfat-resize --grow-partition E: 549755813888
```

## Windows device handling

The Windows backend uses native Windows APIs and does not require a POSIX
compatibility layer.

It provides:

- Unicode command-line and path handling.
- Exclusive access to image files.
- Logical and physical sector-size discovery for volumes.
- Aligned, unbuffered volume I/O.
- Exclusive volume locking for the complete operation.
- Synchronization and dismounting before releasing the volume lock.
- Detailed Windows I/O diagnostics and recovery guidance.

Logical-volume operations require an elevated terminal and all other users of
the volume to be closed.

Physical-disk paths such as `\\.\PhysicalDrive0` are not accepted as command
targets.

## Partition growth safety

`--grow-partition` is deliberately explicit because it changes the partition
table as well as the filesystem.

Automatic growth is limited to a logical volume that maps exactly to one
complete basic GPT or MBR data partition. Before modifying it, the CLI verifies:

- The exFAT boot regions and requested filesystem geometry.
- The logical-volume, partition, extent, and physical-disk mapping.
- The partition type and current disk layout.
- The absence of overlapping layout entries.
- The presence of enough immediately trailing unallocated space.
- The GPT usable range where applicable.

The operation never moves a partition start or another partition and never
shrinks a partition. Dynamic, spanned, service, and otherwise ambiguous layouts
are rejected.

After growth, the CLI refreshes and verifies the exposed partition and volume
geometry before resizing the filesystem.

## Testing

- Added Windows path-classification tests.
- Added Windows image-device and CLI command tests.
- Added Windows package-install coverage.
- Added a VHDX-based CI test using a real exFAT logical volume.
- The logical-volume test covers both drive-letter and volume-GUID paths.
- Partition growth, insufficient-space handling, filesystem validation,
  `chkdsk`, and preservation of test data are verified.
- Windows CI runs with MSVC and without POSIX tools available.
- Existing Linux and macOS test suites remain green.
- The complete GitHub Actions workflow is green.
