### PR TITLE
Handle uncertain Windows partition-growth failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,11 +180,20 @@ jobs:
           name: windows-volume-fixture-${{ github.run_id }}
           path: build/windows-volume-fixture
 
+      - name: Build partition-growth fault-injection CLI
+        shell: pwsh
+        run: |
+          cmake -S . -B build/windows-fault -DEXFAT_RESIZE_BUILD_TESTS=ON
+          cmake --build build/windows-fault --config Release --parallel `
+            --target exfat_resize_partition_fault_test
+
       - name: Resize through drive-letter and volume-GUID paths
         shell: pwsh
         run: |
           ./tests/cli/windows-volume.ps1 `
             -Program $env:EXFAT_RESIZE_WINDOWS_CLI `
+            -FaultProgram `
+              build/windows-fault/tests/cli/Release/exfat_resize_partition_fault_test.exe `
             -Fixture build/windows-volume-fixture/prepared.vhdx `
             -ExpectedHash build/windows-volume-fixture/payload.sha256
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ destructive metadata updates may have started; do not retry the resize, and
 restore the verified backup. Follow a less conservative checker-and-retry path
 only when the command explicitly reports that it is safe.
 
+If `--grow-partition` reports that a partition update was attempted or that the
+partition was enlarged, follow its partition-specific guidance even though no
+filesystem write was attempted. The CLI attempts to dismount a logical volume
+after any partition-update error; prevent further access if that cleanup also
+fails. Verify the partition layout before retrying, and never shrink it as a
+recovery step.
+
 ## Usage
 
     exfat-resize device [ size ]

--- a/src/cli.c
+++ b/src/cli.c
@@ -246,10 +246,18 @@ static void print_partition_grown_guidance(void)
 	    "verify the partition size before retrying and do not shrink it\n");
 }
 
+static void print_partition_update_uncertain_guidance(void)
+{
+	fprintf(stderr,
+	    "exfat-resize: a partition update was attempted, but its result is uncertain; "
+	    "verify the partition layout and do not retry or shrink it\n");
+}
+
 int cli_main(int argc, char **argv)
 {
 	struct exfat_resize_options options;
 	struct device device;
+	enum device_partition_state partition_state = DEVICE_PARTITION_UNCHANGED;
 	enum exfat_resize_error result;
 	enum exfat_resize_stage stage;
 	const char *positional[2];
@@ -258,7 +266,6 @@ int cli_main(int argc, char **argv)
 	int positional_count = 0;
 	int parse_options = 1;
 	int grow_partition = 0;
-	int partition_grown = 0;
 	int status = EXIT_FAILURE;
 	int index;
 
@@ -364,15 +371,24 @@ int cli_main(int argc, char **argv)
 			}
 		}
 		if (device_grow_partition(
-		        &device, positional[0], target, &partition_grown, error, sizeof(error)) != 0) {
+		        &device, positional[0], target, &partition_state, error, sizeof(error)) != 0) {
 			fprintf(stderr, "exfat-resize: %s\n", error);
-			if (partition_grown)
+			if (partition_state == DEVICE_PARTITION_GROWN)
 				print_partition_grown_guidance();
+			else if (partition_state == DEVICE_PARTITION_UPDATE_ATTEMPTED)
+				print_partition_update_uncertain_guidance();
 			else
 				print_no_write_guidance();
+			if (partition_state != DEVICE_PARTITION_UNCHANGED &&
+			    device_dismount(&device, positional[0], error, sizeof(error)) != 0) {
+				fprintf(stderr, "exfat-resize: %s\n", error);
+				fprintf(stderr,
+				    "exfat-resize: the volume may remain mounted; prevent access until the "
+				    "partition layout is verified\n");
+			}
 			goto out;
 		}
-		if (partition_grown) {
+		if (partition_state == DEVICE_PARTITION_GROWN) {
 			printf("exfat-resize: grew the partition containing %s to %" PRIu64 " bytes\n",
 			    positional[0],
 			    device.block_device.sector_count * (uint64_t)device.block_device.sector_size);
@@ -390,7 +406,7 @@ int cli_main(int argc, char **argv)
 		switch (stage) {
 		case EXFAT_RESIZE_STAGE_PREFLIGHT:
 			print_no_write_guidance();
-			if (partition_grown)
+			if (partition_state == DEVICE_PARTITION_GROWN)
 				print_partition_grown_guidance();
 			break;
 		case EXFAT_RESIZE_STAGE_PREPARING:

--- a/src/device.h
+++ b/src/device.h
@@ -27,12 +27,18 @@ struct device {
 	struct exfat_resize_block_device block_device;
 };
 
+enum device_partition_state {
+	DEVICE_PARTITION_UNCHANGED,
+	DEVICE_PARTITION_UPDATE_ATTEMPTED,
+	DEVICE_PARTITION_GROWN
+};
+
 void device_init(struct device *device);
 int device_open(struct device *device, const char *path, char *error, size_t error_size);
 int device_grow_partition(struct device *device,
     const char *path,
     uint64_t target_size,
-    int *partition_grown,
+    enum device_partition_state *partition_state,
     char *error,
     size_t error_size);
 int device_dismount(struct device *device, const char *path, char *error, size_t error_size);

--- a/src/posix/device.c
+++ b/src/posix/device.c
@@ -195,13 +195,13 @@ fail_after_open:
 int device_grow_partition(struct device *device,
     const char *path,
     uint64_t target_size,
-    int *partition_grown,
+    enum device_partition_state *partition_state,
     char *error,
     size_t error_size)
 {
 	(void)device;
 	(void)target_size;
-	*partition_grown = 0;
+	*partition_state = DEVICE_PARTITION_UNCHANGED;
 	(void)snprintf(error, error_size,
 	    "%s: --grow-partition is supported only for logical Windows volumes", path);
 	return -1;

--- a/src/windows/partition.c
+++ b/src/windows/partition.c
@@ -129,7 +129,7 @@ static int checked_end(uint64_t start, uint64_t length, uint64_t *end)
 int device_grow_partition(struct device *device,
     const char *path,
     uint64_t target_size,
-    int *partition_grown,
+    enum device_partition_state *partition_state,
     char *error,
     size_t error_size)
 {
@@ -157,7 +157,7 @@ int device_grow_partition(struct device *device,
 	int path_length;
 	int result = -1;
 
-	*partition_grown = 0;
+	*partition_state = DEVICE_PARTITION_UNCHANGED;
 	if (device->volume_io_buffer == NULL) {
 		windows_device_set_error(
 		    error, error_size, path, "--grow-partition requires a logical Windows volume target");
@@ -323,13 +323,14 @@ int device_grow_partition(struct device *device,
 	(void)memset(&request, 0, sizeof(request));
 	request.PartitionNumber = partition_number;
 	request.BytesToGrow.QuadPart = (LONGLONG)growth;
+	*partition_state = DEVICE_PARTITION_UPDATE_ATTEMPTED;
 	if (!DeviceIoControl(
 	        disk, IOCTL_DISK_GROW_PARTITION, &request, sizeof(request), NULL, 0, &returned, NULL)) {
 		windows_device_set_operation_error(
 		    error, error_size, path, "cannot grow the partition", GetLastError());
 		goto out;
 	}
-	*partition_grown = 1;
+	*partition_state = DEVICE_PARTITION_GROWN;
 	if (!FlushFileBuffers(disk)) {
 		windows_device_set_operation_error(error, error_size, path,
 		    "cannot synchronize the enlarged partition table", GetLastError());

--- a/tests/cli/CMakeLists.txt
+++ b/tests/cli/CMakeLists.txt
@@ -38,6 +38,37 @@ function(exfat_resize_add_device_test target source test_name)
     set_tests_properties(${test_name} PROPERTIES LABELS cli)
 endfunction()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND MSVC)
+    add_executable(
+        exfat_resize_partition_fault_test
+        ${PROJECT_SOURCE_DIR}/src/cli.c
+        ${PROJECT_SOURCE_DIR}/src/windows/device.c
+        ${PROJECT_SOURCE_DIR}/src/windows/device_path.c
+        ${PROJECT_SOURCE_DIR}/src/windows/entry.c
+        ${PROJECT_SOURCE_DIR}/src/windows/partition.c
+        windows-partition-fault.c
+    )
+    target_include_directories(
+        exfat_resize_partition_fault_test
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/lib
+            ${PROJECT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_compile_definitions(
+        exfat_resize_partition_fault_test
+        PRIVATE
+            EXFAT_RESIZE_BUILD_VERSION="${EXFAT_RESIZE_BUILD_VERSION}-partition-fault-test"
+    )
+    target_compile_options(
+        exfat_resize_partition_fault_test
+        PRIVATE
+            "/FI${CMAKE_CURRENT_SOURCE_DIR}/windows-api-redirect.h"
+    )
+    target_link_libraries(exfat_resize_partition_fault_test PRIVATE exfat_resize)
+    exfat_resize_configure_target(exfat_resize_partition_fault_test)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_executable(
         exfat_resize_windows_device_path_test

--- a/tests/cli/windows-api-redirect.h
+++ b/tests/cli/windows-api-redirect.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef EXFAT_RESIZE_TEST_WINDOWS_API_REDIRECT_H
+#define EXFAT_RESIZE_TEST_WINDOWS_API_REDIRECT_H
+
+#include <windows.h>
+
+BOOL WINAPI windows_partition_test_device_io_control(HANDLE handle,
+    DWORD control,
+    LPVOID input,
+    DWORD input_size,
+    LPVOID output,
+    DWORD output_size,
+    LPDWORD returned,
+    LPOVERLAPPED overlapped);
+BOOL WINAPI windows_partition_test_flush_file_buffers(HANDLE handle);
+
+#define DeviceIoControl windows_partition_test_device_io_control
+#define FlushFileBuffers windows_partition_test_flush_file_buffers
+
+#endif

--- a/tests/cli/windows-partition-fault.c
+++ b/tests/cli/windows-partition-fault.c
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: MIT */
+
+#undef DeviceIoControl
+#undef FlushFileBuffers
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <windows.h>
+#include <winioctl.h>
+
+static int partition_grown;
+static int properties_updated;
+
+static int configured_fault(const char *point)
+{
+	const char *configured = getenv("EXFAT_RESIZE_TEST_PARTITION_FAULT");
+	size_t point_length = strlen(point);
+
+	while (configured != NULL && *configured != '\0') {
+		const char *separator = strchr(configured, ',');
+		size_t length = separator == NULL ? strlen(configured) : (size_t)(separator - configured);
+
+		if (length == point_length && memcmp(configured, point, length) == 0) {
+			SetLastError(ERROR_GEN_FAILURE);
+			return 1;
+		}
+		configured = separator == NULL ? NULL : separator + 1;
+	}
+	return 0;
+}
+
+BOOL WINAPI windows_partition_test_device_io_control(HANDLE handle,
+    DWORD control,
+    LPVOID input,
+    DWORD input_size,
+    LPVOID output,
+    DWORD output_size,
+    LPDWORD returned,
+    LPOVERLAPPED overlapped)
+{
+	BOOL succeeded;
+
+	if (control == FSCTL_DISMOUNT_VOLUME && configured_fault("dismount")) {
+		SetLastError(ERROR_GEN_FAILURE);
+		return FALSE;
+	}
+	succeeded = DeviceIoControl(
+	    handle, control, input, input_size, output, output_size, returned, overlapped);
+	if (!succeeded)
+		return FALSE;
+
+	if (control == IOCTL_DISK_GROW_PARTITION) {
+		partition_grown = 1;
+		if (configured_fault("grow-result"))
+			goto fail;
+	} else if (control == IOCTL_DISK_UPDATE_PROPERTIES && partition_grown) {
+		properties_updated = 1;
+		if (configured_fault("refresh"))
+			goto fail;
+	} else if (control == IOCTL_DISK_GET_PARTITION_INFO_EX && properties_updated &&
+	    configured_fault("readback")) {
+		goto fail;
+	} else if (control == FSCTL_DISMOUNT_VOLUME) {
+		fprintf(stderr, "exfat-resize-test: dismounted the volume\n");
+	}
+	return TRUE;
+
+fail:
+	SetLastError(ERROR_GEN_FAILURE);
+	return FALSE;
+}
+
+BOOL WINAPI windows_partition_test_flush_file_buffers(HANDLE handle)
+{
+	BOOL succeeded = FlushFileBuffers(handle);
+
+	if (succeeded && partition_grown && configured_fault("flush")) {
+		SetLastError(ERROR_GEN_FAILURE);
+		return FALSE;
+	}
+	return succeeded;
+}

--- a/tests/cli/windows-volume.ps1
+++ b/tests/cli/windows-volume.ps1
@@ -320,3 +320,4 @@ foreach ($Case in $FaultCases) {
     Test-PartitionFailure $FaultImage $Case[0] $Case[1] $Case[2] $PayloadHash $Case[3]
 }
 Write-Host "windows-volume: passed"
+exit 0

--- a/tests/cli/windows-volume.ps1
+++ b/tests/cli/windows-volume.ps1
@@ -5,6 +5,9 @@ param(
     [string] $Program,
 
     [Parameter(Mandatory = $true)]
+    [string] $FaultProgram,
+
+    [Parameter(Mandatory = $true)]
     [string] $Fixture,
 
     [Parameter(Mandatory = $true)]
@@ -78,6 +81,82 @@ function Invoke-ExpectedFailure {
         "exfat-resize did not report '$ExpectedText'"
     Assert-Condition (($Output -join "`n") -notmatch 'exfat-resize: [A-Za-z]::') `
         "exfat-resize printed duplicate punctuation after a drive designator"
+}
+
+function Test-PartitionFailure {
+    param(
+        [string] $ImagePath,
+        [string] $Fault,
+        [string] $ExpectedError,
+        [string] $ExpectedGuidance,
+        [string] $PayloadHash,
+        [bool] $DismountFailure
+    )
+
+    $Mounted = $false
+    try {
+        $DiskImage = Mount-DiskImage `
+            -ImagePath $ImagePath -StorageType VHDX -Access ReadWrite -PassThru
+        $Mounted = $true
+        $Disk = $DiskImage | Get-Disk
+        $Partition = @(Get-Partition -DiskNumber $Disk.Number |
+            Where-Object { $_.Type -ne "Reserved" })[0]
+        if ([string]::IsNullOrWhiteSpace([string] $Partition.DriveLetter)) {
+            $Partition | Add-PartitionAccessPath -AssignDriveLetter
+            $Partition = Get-Partition -DiskNumber $Disk.Number `
+                -PartitionNumber $Partition.PartitionNumber
+        }
+        $DriveLetter = [char] $Partition.DriveLetter
+        Wait-Volume $DriveLetter | Out-Null
+
+        $env:EXFAT_RESIZE_TEST_PARTITION_FAULT = $Fault
+        try {
+            $TargetSize = [string] ([uint64] 160MB)
+            $Output = & $FaultProgram --grow-partition "$DriveLetter`:" $TargetSize 2>&1
+            $Status = $LASTEXITCODE
+        }
+        finally {
+            Remove-Item Env:EXFAT_RESIZE_TEST_PARTITION_FAULT -ErrorAction SilentlyContinue
+        }
+        $Combined = $Output -join "`n"
+        $Output | ForEach-Object { Write-Host $_ }
+        Assert-Condition ($Status -ne 0) "Fault '$Fault' unexpectedly succeeded"
+        Assert-Condition ($Combined -match [regex]::Escape($ExpectedError)) `
+            "Fault '$Fault' did not report '$ExpectedError'"
+        Assert-Condition ($Combined -match [regex]::Escape($ExpectedGuidance)) `
+            "Fault '$Fault' did not report conservative partition guidance"
+        if ($DismountFailure) {
+            Assert-Condition ($Combined -match 'cannot dismount the volume after resizing') `
+                "Fault '$Fault' did not report the secondary dismount failure"
+            Assert-Condition ($Combined -match 'the volume may remain mounted') `
+                "Fault '$Fault' did not report the mounted-volume precaution"
+        } else {
+            Assert-Condition ($Combined -match 'exfat-resize-test: dismounted the volume') `
+                "Fault '$Fault' did not dismount the volume before releasing its lock"
+        }
+        Assert-Condition ($Combined -notmatch 'no filesystem write was attempted') `
+            "Fault '$Fault' incorrectly reported that no update was attempted"
+
+        Update-HostStorageCache
+        $Partition = Get-Partition -DiskNumber $Disk.Number `
+            -PartitionNumber $Partition.PartitionNumber
+        Assert-Condition ($Partition.Size -eq 160MB) `
+            "Fault '$Fault' did not leave the expected enlarged partition"
+        $Volume = Wait-Volume $DriveLetter
+        Assert-Condition ($Volume.FileSystem -eq "exFAT") `
+            "Fault '$Fault' did not leave a mountable exFAT volume"
+        $ActualHash = (Get-FileHash "$DriveLetter`:\payload.bin" -Algorithm SHA256).Hash
+        Assert-Condition ($ActualHash -eq $PayloadHash) `
+            "Payload differs after partition fault '$Fault'"
+        Write-Host "windows partition fault ($Fault): passed"
+    }
+    finally {
+        Set-Location $env:GITHUB_WORKSPACE
+        if ($Mounted) {
+            Dismount-DiskImage -ImagePath $ImagePath -StorageType VHDX -ErrorAction Continue |
+                Out-Null
+        }
+    }
 }
 
 function Test-VolumeTarget {
@@ -204,6 +283,7 @@ function Test-VolumeTarget {
 }
 
 $Program = (Resolve-Path -LiteralPath $Program).Path
+$FaultProgram = (Resolve-Path -LiteralPath $FaultProgram).Path
 $Fixture = (Resolve-Path -LiteralPath $Fixture).Path
 $PayloadHash = (Get-Content -LiteralPath $ExpectedHash -Raw).Trim().ToUpperInvariant()
 $Temporary = Join-Path $env:RUNNER_TEMP "exfat-resize-windows-volume"
@@ -216,4 +296,27 @@ Copy-Item -LiteralPath $Fixture -Destination $GuidImage -Force
 
 Test-VolumeTarget $DriveImage DriveLetter $PayloadHash
 Test-VolumeTarget $GuidImage VolumeGuid $PayloadHash
+
+$FaultCases = @(
+    @("grow-result", "cannot grow the partition", "a partition update was attempted", $false),
+    @(
+        "flush",
+        "cannot synchronize the enlarged partition table",
+        "the partition was enlarged",
+        $false
+    ),
+    @("refresh", "cannot refresh the enlarged physical disk", "the partition was enlarged", $false),
+    @("readback", "cannot identify the volume partition", "the partition was enlarged", $false),
+    @(
+        "refresh,dismount",
+        "cannot refresh the enlarged physical disk",
+        "the partition was enlarged",
+        $true
+    )
+)
+foreach ($Case in $FaultCases) {
+    $FaultImage = Join-Path $Temporary "partition-fault-$($Case[0]).vhdx"
+    Copy-Item -LiteralPath $Fixture -Destination $FaultImage -Force
+    Test-PartitionFailure $FaultImage $Case[0] $Case[1] $Case[2] $PayloadHash $Case[3]
+}
 Write-Host "windows-volume: passed"


### PR DESCRIPTION
Record partition updates as attempted before issuing the growth IOCTL so a
reported failure cannot be classified as having made no changes. Dismount
the logical volume after every post-attempt error and provide conservative
recovery guidance when the partition state is uncertain.

Add MSVC-only API redirection for disposable-VHDX fault tests without adding
test hooks to production code. Cover failures after growth, synchronization,
property refresh, readback, and dismount.