### PR TITLE
Add binary size suffixes to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ Run `exfat-resize --help` for a command summary. On macOS and Linux,
 `man exfat-resize` provides the complete command-line reference.
 
 With no size, the filesystem grows to the available size of the backing object.
-A specified size is the desired filesystem size as an unsigned number of
-bytes. It is rounded down to a whole filesystem sector. Shrinking is not
-supported.
+A specified size is the desired filesystem size as an unsigned number of bytes.
+It may have an uppercase `K`, `M`, or `G` suffix, which multiplies the number by
+1024, 1024 squared, or 1024 cubed, respectively. The size is rounded down to a
+whole filesystem sector. Shrinking is not supported.
 
 The backing image, device, or partition must provide enough space for the
 requested size before the command runs. The CLI never enlarges an image file.
@@ -176,14 +177,14 @@ These commands grow the filesystem to the existing volume size; they do not
 change its partition table. An explicit size may also be supplied when it fits
 inside the existing volume:
 
-    exfat-resize E: 549755813888
+    exfat-resize E: 512G
 
 #### Growing the containing partition
 
 If an explicit size does not fit inside a logical Windows volume,
 `--grow-partition` asks the CLI to enlarge the containing partition first:
 
-    exfat-resize --grow-partition E: 549755813888
+    exfat-resize --grow-partition E: 512G
 
 This example requests a 512 GiB volume and grows the filesystem to use it. If
 the requested size already fits, the partition table is left unchanged and the

--- a/docs/exfat-resize.8.in
+++ b/docs/exfat-resize.8.in
@@ -34,8 +34,14 @@ sector zero.
 Paths may resolve through symbolic links.
 .TP
 .I SIZE
-The desired filesystem size in bytes, written as an unsigned decimal integer
-without a unit suffix.
+The desired filesystem size, written as an unsigned decimal integer.
+An optional uppercase
+.BR K ,
+.BR M ,
+or
+.B G
+suffix multiplies the value by 1024, 1048576, or 1073741824, respectively.
+Without a suffix, the value is interpreted as bytes.
 The value must be greater than zero.
 .SH OPTIONS
 .TP

--- a/src/cli.c
+++ b/src/cli.c
@@ -72,7 +72,8 @@ static void print_help(void)
 	       "\n"
 	       "Arguments:\n"
 	       "  %-18s %s\n"
-	       "  SIZE               Desired filesystem size in bytes\n"
+	       "  SIZE               Desired filesystem size in bytes or with an optional\n"
+	       "                     K, M, or G suffix (powers of 1024)\n"
 	       "                     (default: all available space)\n"
 	       "\n"
 	       "Options:\n"
@@ -157,24 +158,41 @@ static void deallocate_memory(void *context, void *memory, size_t size)
 
 static int parse_size(const char *text, uint64_t *value)
 {
+	const char *cursor = text;
+	uint64_t multiplier = 1;
 	uint64_t parsed = 0;
 
-	if (*text == '\0')
+	if (*cursor == '\0')
 		return -1;
-	while (*text != '\0') {
+	while (*cursor >= '0' && *cursor <= '9') {
 		uint64_t digit;
 
-		if (*text < '0' || *text > '9')
-			return -1;
-		digit = (uint64_t)(*text - '0');
+		digit = (uint64_t)(*cursor - '0');
 		if (parsed > (UINT64_MAX - digit) / 10)
 			return -1;
 		parsed = parsed * 10 + digit;
-		++text;
+		++cursor;
 	}
-	if (parsed == 0)
+	switch (*cursor) {
+	case '\0':
+		break;
+	case 'K':
+		multiplier = UINT64_C(1024);
+		break;
+	case 'M':
+		multiplier = UINT64_C(1024) * 1024;
+		break;
+	case 'G':
+		multiplier = UINT64_C(1024) * 1024 * 1024;
+		break;
+	default:
 		return -1;
-	*value = parsed;
+	}
+	if (*cursor != '\0' && cursor[1] != '\0')
+		return -1;
+	if (parsed == 0 || parsed > UINT64_MAX / multiplier)
+		return -1;
+	*value = parsed * multiplier;
 	return 0;
 }
 

--- a/tests/cli/explicit-size.sh
+++ b/tests/cli/explicit-size.sh
@@ -6,6 +6,8 @@ set -eu
 program=$1
 temporary=${TMPDIR:-/tmp}/exfat-resize-size-test.$$
 image=$temporary/image.exfat
+kibibyte_image=$temporary/kibibyte.exfat
+mebibyte_image=$temporary/mebibyte.exfat
 
 . "$(dirname "$0")/lib.sh"
 
@@ -19,6 +21,24 @@ mkdir -p "$temporary"
 expect_failure() {
 	if "$@" >"$temporary/rejected.out" 2>&1; then
 		echo "command unexpectedly succeeded: $*" >&2
+		return 1
+	fi
+}
+
+expect_invalid_size() {
+	size=$1
+	expect_failure "$program" "$temporary/missing.exfat" "$size"
+	if ! grep -Fq "exfat-resize: invalid size: $size" "$temporary/rejected.out"; then
+		echo "size was not rejected by the parser: $size" >&2
+		return 1
+	fi
+}
+
+expect_valid_size_syntax() {
+	size=$1
+	expect_failure "$program" "$temporary/missing.exfat" "$size"
+	if grep -Fq "exfat-resize: invalid size:" "$temporary/rejected.out"; then
+		echo "valid size syntax was rejected: $size" >&2
 		return 1
 	fi
 }
@@ -53,12 +73,43 @@ if [ "$(read_volume_sector_count "$image")" -ne "$target_sectors" ]; then
 fi
 
 check_exfat_image "$image"
-expect_failure "$program" "$image" 0
-expect_failure "$program" "$image" not-a-number
 expect_failure "$program" "$image" "$target_bytes"
 expect_failure "$program" "$image" "$((target_sectors * sector_size - 1))"
 expect_failure "$program" "$image" "$((backing_bytes + sector_size))"
 expect_failure "$program" "$image" 18446744073709551615
 check_exfat_image "$image"
+
+format_exfat_image "$kibibyte_image" 65536 131072
+output=$("$program" "$kibibyte_image" 49152K)
+if [ "$output" != "exfat-resize: resized $kibibyte_image" ]; then
+	echo "unexpected K-suffix resize output: $output" >&2
+	exit 1
+fi
+if [ "$(read_volume_sector_count "$kibibyte_image")" -ne 98304 ]; then
+	echo "K-suffix size produced the wrong filesystem length" >&2
+	exit 1
+fi
+check_exfat_image "$kibibyte_image"
+
+format_exfat_image "$mebibyte_image" 65536 131072
+output=$("$program" "$mebibyte_image" 48M)
+if [ "$output" != "exfat-resize: resized $mebibyte_image" ]; then
+	echo "unexpected M-suffix resize output: $output" >&2
+	exit 1
+fi
+if [ "$(read_volume_sector_count "$mebibyte_image")" -ne 98304 ]; then
+	echo "M-suffix size produced the wrong filesystem length" >&2
+	exit 1
+fi
+check_exfat_image "$mebibyte_image"
+
+for size in 18446744073709551615 1K 1M 1G 18014398509481983K 17592186044415M \
+	17179869183G; do
+	expect_valid_size_syntax "$size"
+done
+for size in 0 0K K not-a-number 1k 1m 1g 1T 1KB 1KiB 1.5G 1GG +1G \
+	18446744073709551616 18014398509481984K 17592186044416M 17179869184G; do
+	expect_invalid_size "$size"
+done
 
 echo "explicit-size: passed"

--- a/tests/cli/help.sh
+++ b/tests/cli/help.sh
@@ -18,7 +18,8 @@ require_text() {
 
 require_text "Usage: exfat-resize DEVICE [SIZE]"
 require_text "Arguments:"
-require_text "Desired filesystem size in bytes"
+require_text "Desired filesystem size in bytes or with an optional"
+require_text "K, M, or G suffix (powers of 1024)"
 require_text "Options:"
 require_text "Safety:"
 require_text "Documentation:"

--- a/tests/cli/windows-command-test.cmake
+++ b/tests/cli/windows-command-test.cmake
@@ -52,7 +52,8 @@ if(TEST_CASE STREQUAL "help")
             "Usage: exfat-resize DEVICE [SIZE]"
             "exfat-resize --grow-partition DEVICE SIZE"
             "Arguments:"
-            "Desired filesystem size in bytes"
+            "Desired filesystem size in bytes or with an optional"
+            "K, M, or G suffix (powers of 1024)"
             "Options:"
             "Safety:"
             "Documentation:"
@@ -73,6 +74,11 @@ elseif(TEST_CASE STREQUAL "recovery-guidance")
     expect_no_write_failure(--grow-partition [[E:]])
     require_text("${command_output}" "--grow-partition requires an explicit SIZE")
     expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/missing.exfat" 0)
+    require_text("${command_output}" "invalid size: 0")
+    expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/missing.exfat" 1G)
+    require_text("${command_output}" "missing.exfat")
+    expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/missing.exfat" 1T)
+    require_text("${command_output}" "invalid size: 1T")
     expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/missing.exfat")
     expect_no_write_failure("${CMAKE_CURRENT_BINARY_DIR}/exfat-resize-Ω-missing.exfat")
     require_text("${command_output}" "exfat-resize-Ω-missing.exfat")


### PR DESCRIPTION
Accept uppercase K, M, and G suffixes for explicit sizes using powers of 1024. Reject invalid and overflowing values, and update CLI tests, help text, documentation, and examples.