### PR TITLE
Add macOS ARM64 binary release

### DIFF
--- a/.github/workflows/macos-binary.yml
+++ b/.github/workflows/macos-binary.yml
@@ -81,6 +81,10 @@ jobs:
           test "$(printf '%s\n' "$binary_archive" | wc -l)" -eq 1
           "$source_directory/tests/package/macos-binary-test.sh" \
             "$binary_archive" "$source_directory"
+          archive_sha256=$(shasum -a 256 "$binary_archive" | awk '{ print $1 }')
+          content_sha256=$(gzip -dc "$binary_archive" | shasum -a 256 | awk '{ print $1 }')
+          printf 'unsigned archive SHA-256: %s\n' "$archive_sha256"
+          printf 'uncompressed tar SHA-256: %s\n' "$content_sha256"
 
       - name: Upload tested unsigned macOS archive
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos-binary.yml
+++ b/.github/workflows/macos-binary.yml
@@ -81,10 +81,20 @@ jobs:
           test "$(printf '%s\n' "$binary_archive" | wc -l)" -eq 1
           "$source_directory/tests/package/macos-binary-test.sh" \
             "$binary_archive" "$source_directory"
-          archive_sha256=$(shasum -a 256 "$binary_archive" | awk '{ print $1 }')
-          content_sha256=$(gzip -dc "$binary_archive" | shasum -a 256 | awk '{ print $1 }')
-          printf 'unsigned archive SHA-256: %s\n' "$archive_sha256"
-          printf 'uncompressed tar SHA-256: %s\n' "$content_sha256"
+
+          package=$(basename "$binary_archive" .tar.gz)
+          mkdir -p signing-probe/extracted assembled-probe
+          tar -xzf "$binary_archive" -C signing-probe/extracted
+          signed_executable=signing-probe/$package.signed
+          install -m 0755 \
+            "signing-probe/extracted/$package/exfat-resize" "$signed_executable"
+          codesign --force --identifier exfat-resize --options runtime \
+            --sign - "$signed_executable"
+          "$source_directory/tools/assemble-macos-binary.sh" \
+            "$binary_archive" "$signed_executable" assembled-probe
+          assembled_archive=assembled-probe/$package.tar.gz
+          "$source_directory/tests/package/macos-binary-test.sh" \
+            "$assembled_archive" "$source_directory"
 
       - name: Upload tested unsigned macOS archive
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos-binary.yml
+++ b/.github/workflows/macos-binary.yml
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+
+name: macOS binary
+
+on:
+  workflow_call:
+    inputs:
+      source_artifact_name:
+        description: Artifact containing the tested source archive
+        required: true
+        type: string
+      binary_artifact_name:
+        description: Artifact name for the tested unsigned macOS archive
+        required: true
+        type: string
+      expected_version:
+        description: Optional tag or version that the binary must match
+        required: false
+        default: ""
+        type: string
+      retention_days:
+        description: Artifact retention days; 0 uses the repository default
+        required: false
+        default: 0
+        type: number
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test (Apple Clang, ARM64, macOS 11 target)
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      EXPECTED_VERSION: ${{ inputs.expected_version }}
+
+    steps:
+      - name: Download tested source archive
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.source_artifact_name }}
+          path: source-artifacts
+
+      - name: Record builder environment
+        run: |
+          sw_vers
+          uname -a
+          clang --version
+          cmake --version
+          xcrun --show-sdk-version
+
+      - name: Build and test unsigned macOS binary archive
+        run: |
+          set -eu
+          test "$(uname -s)" = Darwin
+          test "$(uname -m)" = arm64
+          archive=$(find source-artifacts -maxdepth 1 -type f \
+            -name 'exfat-resize-*.tar.gz' -print)
+          test -n "$archive"
+          test "$(printf '%s\n' "$archive" | wc -l)" -eq 1
+
+          mkdir source-tree
+          tar -xzf "$archive" -C source-tree
+          source_directory=$(find source-tree -mindepth 1 -maxdepth 1 \
+            -type d -name 'exfat-resize-*' -print)
+          test -n "$source_directory"
+          test "$(printf '%s\n' "$source_directory" | wc -l)" -eq 1
+
+          if [ -n "$EXPECTED_VERSION" ]; then
+            expected_version=${EXPECTED_VERSION#v}
+            actual_version=$(sed -n '1p' "$source_directory/.tarball-version")
+            test "$actual_version" = "$expected_version"
+          fi
+
+          "$source_directory/tools/build-macos-binary.sh" \
+            "$source_directory" macos-artifacts
+          binary_archive=$(find macos-artifacts -maxdepth 1 -type f \
+            -name 'exfat-resize-*-macos-arm64.tar.gz' -print)
+          test -n "$binary_archive"
+          test "$(printf '%s\n' "$binary_archive" | wc -l)" -eq 1
+          "$source_directory/tests/package/macos-binary-test.sh" \
+            "$binary_archive" "$source_directory"
+
+      - name: Upload tested unsigned macOS archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.binary_artifact_name }}
+          path: macos-artifacts/exfat-resize-*-macos-arm64.tar.gz
+          if-no-files-found: error
+          overwrite: true
+          retention-days: ${{ inputs.retention_days }}

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -195,3 +195,66 @@ jobs:
             printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
             exit 1
           fi
+
+  verify_macos_release:
+    name: Verify signed macOS release asset
+    needs: [build_source, publish_draft]
+    runs-on: macos-15
+    timeout-minutes: 30
+    environment:
+      name: macos-release
+      url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+    permissions:
+      contents: read
+    env:
+      EXPECTED_TEAM_ID: X5X5M4XA99
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_REF: ${{ github.ref_name }}
+
+    steps:
+      - name: Download tested source archive
+        uses: actions/download-artifact@v4
+        with:
+          name: source-release-${{ github.ref_name }}-${{ github.run_id }}
+          path: source-artifacts
+
+      - name: Download signed macOS archive from draft release
+        run: |
+          set -euo pipefail
+          is_draft=$(gh release view "$RELEASE_REF" --json isDraft --jq .isDraft)
+          test "$is_draft" = true
+          version=${RELEASE_REF#v}
+          archive=exfat-resize-$version-macos-arm64.tar.gz
+          mkdir signed-release-assets
+          gh release download "$RELEASE_REF" --pattern "$archive" --dir signed-release-assets
+          test -f "signed-release-assets/$archive"
+
+          archive_sha256=$(shasum -a 256 "signed-release-assets/$archive" | awk '{ print $1 }')
+          published_digest=$(
+            gh release view "$RELEASE_REF" --json assets \
+              --jq ".assets[] | select(.name == \"$archive\") | .digest"
+          )
+          test "$published_digest" = "sha256:$archive_sha256"
+          printf 'signed release archive SHA-256: %s\n' "$archive_sha256"
+
+      - name: Verify signed macOS archive
+        run: |
+          set -euo pipefail
+          version=${RELEASE_REF#v}
+          archive=signed-release-assets/exfat-resize-$version-macos-arm64.tar.gz
+          source_archive=$(find source-artifacts -maxdepth 1 -type f \
+            -name 'exfat-resize-*.tar.gz' -print)
+          test -n "$source_archive"
+          test "$(printf '%s\n' "$source_archive" | wc -l)" -eq 1
+
+          mkdir source-tree
+          tar -xzf "$source_archive" -C source-tree
+          source_directory=$(find source-tree -mindepth 1 -maxdepth 1 \
+            -type d -name 'exfat-resize-*' -print)
+          test -n "$source_directory"
+          test "$(printf '%s\n' "$source_directory" | wc -l)" -eq 1
+          test "$(sed -n '1p' "$source_directory/.tarball-version")" = "$version"
+
+          "$source_directory/tests/package/macos-binary-test.sh" \
+            --developer-id-team "$EXPECTED_TEAM_ID" "$archive" "$source_directory"

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -87,9 +87,20 @@ jobs:
       binary_artifact_name: windows-release-${{ github.ref_name }}-${{ github.run_id }}
       expected_version: ${{ github.ref_name }}
 
+  build_macos:
+    name: Unsigned macOS binary archive
+    needs: build_source
+    permissions:
+      contents: read
+    uses: ./.github/workflows/macos-binary.yml
+    with:
+      source_artifact_name: source-release-${{ github.ref_name }}-${{ github.run_id }}
+      binary_artifact_name: macos-unsigned-${{ github.ref_name }}-${{ github.run_id }}
+      expected_version: ${{ github.ref_name }}
+
   publish_draft:
     name: Create draft release
-    needs: [build_source, build_linux, build_windows]
+    needs: [build_source, build_linux, build_windows, build_macos]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -197,15 +197,15 @@ jobs:
           fi
 
   verify_macos_release:
-    name: Verify signed macOS release asset
-    needs: [build_source, publish_draft]
+    name: Assemble signed macOS release asset
+    needs: [build_source, build_macos, publish_draft]
     runs-on: macos-15
     timeout-minutes: 30
     environment:
       name: macos-release
       url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
     permissions:
-      contents: read
+      contents: write
     env:
       EXPECTED_TEAM_ID: X5X5M4XA99
       GH_REPO: ${{ github.repository }}
@@ -219,30 +219,38 @@ jobs:
           name: source-release-${{ github.ref_name }}-${{ github.run_id }}
           path: source-artifacts
 
-      - name: Download signed macOS archive from draft release
+      - name: Download tested unsigned macOS archive
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-unsigned-${{ github.ref_name }}-${{ github.run_id }}
+          path: macos-artifacts
+
+      - name: Download signed macOS executable from draft release
         run: |
           set -euo pipefail
           is_draft=$(gh release view "$RELEASE_REF" --json isDraft --jq .isDraft)
           test "$is_draft" = true
           version=${RELEASE_REF#v}
-          archive=exfat-resize-$version-macos-arm64.tar.gz
+          executable=exfat-resize-$version-macos-arm64.signed
           mkdir signed-release-assets
-          gh release download "$RELEASE_REF" --pattern "$archive" --dir signed-release-assets
-          test -f "signed-release-assets/$archive"
+          gh release download "$RELEASE_REF" --pattern "$executable" \
+            --dir signed-release-assets
+          test -f "signed-release-assets/$executable"
 
-          archive_sha256=$(shasum -a 256 "signed-release-assets/$archive" | awk '{ print $1 }')
+          executable_sha256=$(
+            shasum -a 256 "signed-release-assets/$executable" | awk '{ print $1 }'
+          )
           published_digest=$(
             gh release view "$RELEASE_REF" --json assets \
-              --jq ".assets[] | select(.name == \"$archive\") | .digest"
+              --jq ".assets[] | select(.name == \"$executable\") | .digest"
           )
-          test "$published_digest" = "sha256:$archive_sha256"
-          printf 'signed release archive SHA-256: %s\n' "$archive_sha256"
+          test "$published_digest" = "sha256:$executable_sha256"
+          printf 'signed executable SHA-256: %s\n' "$executable_sha256"
 
-      - name: Verify signed macOS archive
+      - name: Assemble and verify signed macOS archive
         run: |
           set -euo pipefail
           version=${RELEASE_REF#v}
-          archive=signed-release-assets/exfat-resize-$version-macos-arm64.tar.gz
           source_archive=$(find source-artifacts -maxdepth 1 -type f \
             -name 'exfat-resize-*.tar.gz' -print)
           test -n "$source_archive"
@@ -256,5 +264,46 @@ jobs:
           test "$(printf '%s\n' "$source_directory" | wc -l)" -eq 1
           test "$(sed -n '1p' "$source_directory/.tarball-version")" = "$version"
 
+          unsigned_archive=$(find macos-artifacts -maxdepth 1 -type f \
+            -name "exfat-resize-$version-macos-arm64.tar.gz" -print)
+          test -n "$unsigned_archive"
+          test "$(printf '%s\n' "$unsigned_archive" | wc -l)" -eq 1
+          signed_executable=signed-release-assets/exfat-resize-$version-macos-arm64.signed
+          "$source_directory/tools/assemble-macos-binary.sh" \
+            "$unsigned_archive" "$signed_executable" final-release-assets
+          archive=final-release-assets/exfat-resize-$version-macos-arm64.tar.gz
           "$source_directory/tests/package/macos-binary-test.sh" \
             --developer-id-team "$EXPECTED_TEAM_ID" "$archive" "$source_directory"
+
+      - name: Upload verified macOS archive and remove signing handoff
+        run: |
+          set -euo pipefail
+          version=${RELEASE_REF#v}
+          source_archive=exfat-resize-$version.tar.gz
+          linux_archive=exfat-resize-$version-linux-x86_64-glibc.tar.gz
+          windows_archive=exfat-resize-$version-windows-x86_64.zip
+          macos_archive=exfat-resize-$version-macos-arm64.tar.gz
+          signed_executable=exfat-resize-$version-macos-arm64.signed
+          archive_path=final-release-assets/$macos_archive
+
+          gh release upload "$RELEASE_REF" "$archive_path" --clobber
+          archive_sha256=$(shasum -a 256 "$archive_path" | awk '{ print $1 }')
+          published_digest=$(
+            gh release view "$RELEASE_REF" --json assets \
+              --jq ".assets[] | select(.name == \"$macos_archive\") | .digest"
+          )
+          test "$published_digest" = "sha256:$archive_sha256"
+
+          expected=$(
+            printf '%s\n' "$source_archive" "$linux_archive" "$windows_archive" \
+              "$macos_archive" "$signed_executable" | sort
+          )
+          actual=$(gh release view "$RELEASE_REF" --json assets --jq '.assets[].name' | sort)
+          if [ "$actual" != "$expected" ]; then
+            echo "draft release contains an unexpected asset set" >&2
+            printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+            exit 1
+          fi
+
+          printf 'verified macOS release archive SHA-256: %s\n' "$archive_sha256"
+          gh release delete-asset "$RELEASE_REF" "$signed_executable" --yes

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -278,6 +278,14 @@ jobs:
       - name: Upload verified macOS archive and remove signing handoff
         run: |
           set -euo pipefail
+          require_draft_release() {
+            is_draft=$(gh release view "$RELEASE_REF" --json isDraft --jq .isDraft)
+            if [ "$is_draft" != true ]; then
+              echo "refusing to modify published release $RELEASE_REF" >&2
+              exit 1
+            fi
+          }
+
           version=${RELEASE_REF#v}
           source_archive=exfat-resize-$version.tar.gz
           linux_archive=exfat-resize-$version-linux-x86_64-glibc.tar.gz
@@ -286,6 +294,7 @@ jobs:
           signed_executable=exfat-resize-$version-macos-arm64.signed
           archive_path=final-release-assets/$macos_archive
 
+          require_draft_release
           gh release upload "$RELEASE_REF" "$archive_path" --clobber
           archive_sha256=$(shasum -a 256 "$archive_path" | awk '{ print $1 }')
           published_digest=$(
@@ -306,4 +315,5 @@ jobs:
           fi
 
           printf 'verified macOS release archive SHA-256: %s\n' "$archive_sha256"
+          require_draft_release
           gh release delete-asset "$RELEASE_REF" "$signed_executable" --yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,6 +289,15 @@ jobs:
       binary_artifact_name: linux-binary-ci-${{ github.run_id }}
       retention_days: 1
 
+  macos-binary:
+    name: macOS binary archive
+    needs: release-package
+    uses: ./.github/workflows/macos-binary.yml
+    with:
+      source_artifact_name: source-ci-${{ github.run_id }}
+      binary_artifact_name: macos-binary-ci-${{ github.run_id }}
+      retention_days: 1
+
   windows-binary:
     name: Windows binary archive
     needs: release-package

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ exfat-resize provides:
 Prebuilt CLI binaries are provided for these platforms:
 
 - Linux x86-64 with glibc
+- macOS 11 or newer on Apple silicon (ARM64)
 - Windows x86-64
 
 Download the prebuilt CLI from
@@ -21,6 +22,12 @@ SHA-256 digest shown by GitHub. On Linux:
 
     tar -xzf exfat-resize-X.Y.Z-linux-x86_64-glibc.tar.gz
     cd exfat-resize-X.Y.Z-linux-x86_64-glibc
+    sudo ./install.sh
+
+On macOS:
+
+    tar -xzf exfat-resize-X.Y.Z-macos-arm64.tar.gz
+    cd exfat-resize-X.Y.Z-macos-arm64
     sudo ./install.sh
 
 On Windows PowerShell, no installation is required:
@@ -369,25 +376,38 @@ new major release.
 
 ## Installing prebuilt CLI binaries
 
-### Linux
+### Linux and macOS
 
-GitHub Releases provide a prebuilt CLI archive expected to run on all conventional
-`x86_64` Linux distributions using glibc 2.28 or newer. It is built on
-AlmaLinux 8.10 and tested by performing an exFAT resize on Debian 12 and Ubuntu
-22.04 LTS. Musl-based distributions such as Alpine, non-FHS systems such as
-NixOS, and other CPU architectures require a different build or compatibility
-setup.
+GitHub Releases provide two Unix CLI archives:
 
-Download `exfat-resize-X.Y.Z-linux-x86_64-glibc.tar.gz` from the corresponding
+- `exfat-resize-X.Y.Z-macos-arm64.tar.gz` supports macOS 11 or newer on Apple
+  silicon. It is ARM64-only, Developer ID-signed, and notarized by Apple.
+- `exfat-resize-X.Y.Z-linux-x86_64-glibc.tar.gz` supports conventional `x86_64`
+  Linux distributions using glibc 2.28 or newer. It is built on AlmaLinux 8.10
+  and tested by performing an exFAT resize on Debian 12 and Ubuntu 22.04 LTS.
+  Musl-based distributions such as Alpine, non-FHS systems such as NixOS, and
+  other CPU architectures require a different build or compatibility setup.
+
+Download the archive for the target platform from the corresponding
 [GitHub Release](https://github.com/huven/exfat-resize/releases). GitHub displays
-an immutable SHA-256 digest beside the asset; compare it with the output of:
+an immutable SHA-256 digest beside each asset. On macOS, compare it with:
+
+    shasum -a 256 exfat-resize-X.Y.Z-macos-arm64.tar.gz
+
+Then extract the macOS archive and enter its directory:
+
+    tar -xzf exfat-resize-X.Y.Z-macos-arm64.tar.gz
+    cd exfat-resize-X.Y.Z-macos-arm64
+
+On Linux, compare and extract with:
 
     sha256sum exfat-resize-X.Y.Z-linux-x86_64-glibc.tar.gz
-
-Replace `X.Y.Z` below with the release version, then extract and install it:
-
     tar -xzf exfat-resize-X.Y.Z-linux-x86_64-glibc.tar.gz
     cd exfat-resize-X.Y.Z-linux-x86_64-glibc
+
+Replace `X.Y.Z` with the release version. From the extracted directory on
+either platform, install the CLI, manual page, and documentation with:
+
     sudo ./install.sh
 
 The installer defaults to `/usr/local`. To use another absolute prefix, set
@@ -403,6 +423,10 @@ installed files:
 For a custom prefix, remove it with:
 
     PREFIX=/your/prefix ./uninstall.sh
+
+Apple does not support attaching a notarization ticket directly to a standalone
+command-line executable. A Mac therefore needs network access when Gatekeeper
+first checks a newly downloaded copy of the macOS binary.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,9 @@ GitHub Releases provide two Unix CLI archives:
 
 Download the archive for the target platform from the corresponding
 [GitHub Release](https://github.com/huven/exfat-resize/releases). GitHub displays
-an immutable SHA-256 digest beside each asset. On macOS, compare it with:
+an immutable SHA-256 digest beside each asset. When using Safari, Option-click
+the macOS asset link so Safari downloads it without automatically opening and
+decompressing it. Compare the retained `.tar.gz` with GitHub's digest:
 
     shasum -a 256 exfat-resize-X.Y.Z-macos-arm64.tar.gz
 

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -43,40 +43,47 @@ The routine release procedure has six steps:
    the `macos-release` environment approval.
 4. Download the unsigned macOS workflow artifact, then sign and notarize it as
    described below.
-5. Upload the signed macOS archive to the draft and approve the waiting
+5. Upload the signed macOS executable to the draft and approve the waiting
    `macos-release` job.
-6. Wait for signed-archive verification, review the generated notes and all
-   assets, then publish the draft manually.
+6. Wait for GitHub to assemble and verify the signed archive, review the
+   generated notes and all assets, then publish the draft manually.
 
 The maintainer does not run `make dist`, create the GitHub Release, or calculate
-release checksums. The signed macOS archive is the only asset uploaded manually.
+release checksums. A temporary signed macOS executable is the only file uploaded
+manually; the workflow removes it after constructing the final archive.
 
 The workflow creates or updates a draft release; it never modifies an already
-published release. A failed run can therefore be rerun safely. Review the
-generated notes and assets before publishing the draft manually.
+published release. If assembly or verification fails, use **Re-run failed jobs**
+to retain the uploaded executable. **Re-run all jobs** also reruns draft creation,
+which deletes every existing draft asset; upload the same signed executable again
+when the workflow returns to the approval. Neither case requires replacing the
+release tag. Review the generated notes and assets before publishing the draft
+manually.
 
 The repository must have a protected GitHub environment named `macos-release`
 with the maintainer as a required reviewer. Do not enable prevention of
 self-review for a release initiated by that maintainer. The environment stores
 no signing credentials; it only holds the verification job until the signed
-archive has been uploaded to the draft.
+executable has been uploaded to the draft.
 
-## Signing the macOS binary archive
+## Signing the macOS executable
 
 The `Test` and `Release` workflows retain the tested, ad-hoc-signed macOS
 archive as a workflow artifact. Download that artifact separately; do not give
-the signing helper GitHub credentials. The build log prints both the compressed
-archive SHA-256 and the SHA-256 of its uncompressed tar stream. The latter
-remains comparable if Safari automatically expands the `.tar.gz` to `.tar`.
+the signing helper GitHub credentials. When using Safari, Option-click the
+artifact download link so Safari downloads it without automatically opening and
+decompressing it. GitHub displays the SHA-256 of the downloaded artifact ZIP on
+the workflow run page.
 
-Before signing, compare the reported digest and run the local preflight:
+Before extracting the artifact, compare that displayed digest with the ZIP, then
+extract it and run the local preflight:
 
-    shasum -a 256 exfat-resize-X.Y.Z-macos-arm64.tar
-    tools/sign-macos-binary.sh --check exfat-resize-X.Y.Z-macos-arm64.tar
+    shasum -a 256 macos-unsigned-vX.Y.Z-RUN_ID.zip
+    unzip macos-unsigned-vX.Y.Z-RUN_ID.zip
+    tools/sign-macos-binary.sh --check exfat-resize-X.Y.Z-macos-arm64.tar.gz
 
-The helper accepts either `.tar.gz` or a Safari-expanded `.tar`. Its
-`uncompressed tar SHA-256` output must match the corresponding value in the
-workflow log.
+The ZIP digest must match the value on the artifact download page. Because the
+artifact is immutable, that check also authenticates the enclosed `.tar.gz`.
 
 Signing requires a Developer ID Application certificate in the login Keychain
 and notarization credentials stored under a `notarytool` Keychain profile. List
@@ -86,28 +93,34 @@ signing run:
     security find-identity -v -p codesigning
     xcrun notarytool store-credentials exfat-resize-notary
 
-Sign and notarize the archive into a separate output directory:
+Sign and notarize the executable from the archive into a separate output
+directory:
 
     tools/sign-macos-binary.sh \
         --identity "Developer ID Application: NAME (TEAMID)" \
         --notary-profile exfat-resize-notary \
-        exfat-resize-X.Y.Z-macos-arm64.tar signed
+        exfat-resize-X.Y.Z-macos-arm64.tar.gz signed
 
-The helper validates the complete unsigned package before accessing the signing
-identity. It then signs only the CLI with the hardened runtime and a secure
-timestamp, submits a temporary ZIP to Apple, retrieves the notarization log,
-and creates the final `.tar.gz`. Because Apple does not support stapling a ticket
-to a standalone executable, the helper verifies the ticket with the online
-notarization check supported by `codesign`. The output directory receives the
-final archive and its notarization log. Upload only the archive to the draft
-GitHub Release, then approve the pending `macos-release` environment job.
+Before accessing the signing identity, the helper selectively extracts exactly
+one regular CLI entry and validates its version, architecture, deployment target,
+dependencies, and ad-hoc signature. It then signs the CLI with the hardened
+runtime and a secure timestamp, submits a temporary ZIP to Apple, retrieves the
+notarization log, and writes `exfat-resize-X.Y.Z-macos-arm64.signed` alongside
+that log. Because Apple does not support stapling a ticket to a standalone
+executable, the helper verifies the ticket with the online notarization check
+supported by `codesign`. Upload only the `.signed` executable to the draft GitHub
+Release, then approve the pending `macos-release` environment job.
 
-The approved job downloads the exact draft asset on a fresh macOS runner. It
-checks the GitHub asset digest, package version and contents, ARM64 architecture,
-deployment target, dependencies, Developer ID team, secure timestamp, hardened
-runtime, and online notarization ticket. It also exercises installation and
-uninstallation and performs an actual exFAT resize. The job never publishes the
-draft; publication remains a separate manual action after all checks pass.
+The approved job downloads that exact draft asset and its own tested unsigned
+archive on a fresh macOS runner. It verifies that removing and canonicalizing the
+signatures leaves the same executable GitHub built, then replaces only the CLI in
+the trusted unsigned archive. It checks the GitHub asset digests, package version
+and contents, ARM64 architecture, deployment target, dependencies, Developer ID
+team, code-signing identifier, secure timestamp, hardened runtime, absence of
+entitlements, and online notarization ticket. It also exercises installation and
+uninstallation and performs an actual exFAT resize. After uploading the verified
+final archive, it removes the temporary `.signed` asset. The job never publishes
+the draft; publication remains a separate manual action after all checks pass.
 
 ## Creating a signed release tag
 

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -33,22 +33,81 @@ present in the checkout. The archive stores that identity in
 
 ## Release procedure
 
-The routine release procedure has three steps:
+The routine release procedure has six steps:
 
 1. Update `VERSION` in a pull request, wait for all required checks, and merge
    it to `main`.
 2. Check out the resulting release commit and create and push its signed
    `vX.Y.Z` tag using the command below.
-3. Wait for the `Release` workflow, review its generated notes and the source,
-   Linux, and Windows assets in the draft GitHub Release, then publish the
-   draft manually.
+3. Wait for the `Release` workflow to create the draft GitHub Release and reach
+   the `macos-release` environment approval.
+4. Download the unsigned macOS workflow artifact, then sign and notarize it as
+   described below.
+5. Upload the signed macOS archive to the draft and approve the waiting
+   `macos-release` job.
+6. Wait for signed-archive verification, review the generated notes and all
+   assets, then publish the draft manually.
 
-The maintainer does not run `make dist`, create the GitHub Release, calculate
-checksums, or upload assets during a routine release.
+The maintainer does not run `make dist`, create the GitHub Release, or calculate
+release checksums. The signed macOS archive is the only asset uploaded manually.
 
 The workflow creates or updates a draft release; it never modifies an already
 published release. A failed run can therefore be rerun safely. Review the
 generated notes and assets before publishing the draft manually.
+
+The repository must have a protected GitHub environment named `macos-release`
+with the maintainer as a required reviewer. Do not enable prevention of
+self-review for a release initiated by that maintainer. The environment stores
+no signing credentials; it only holds the verification job until the signed
+archive has been uploaded to the draft.
+
+## Signing the macOS binary archive
+
+The `Test` and `Release` workflows retain the tested, ad-hoc-signed macOS
+archive as a workflow artifact. Download that artifact separately; do not give
+the signing helper GitHub credentials. The build log prints both the compressed
+archive SHA-256 and the SHA-256 of its uncompressed tar stream. The latter
+remains comparable if Safari automatically expands the `.tar.gz` to `.tar`.
+
+Before signing, compare the reported digest and run the local preflight:
+
+    shasum -a 256 exfat-resize-X.Y.Z-macos-arm64.tar
+    tools/sign-macos-binary.sh --check exfat-resize-X.Y.Z-macos-arm64.tar
+
+The helper accepts either `.tar.gz` or a Safari-expanded `.tar`. Its
+`uncompressed tar SHA-256` output must match the corresponding value in the
+workflow log.
+
+Signing requires a Developer ID Application certificate in the login Keychain
+and notarization credentials stored under a `notarytool` Keychain profile. List
+the available signing identities and create the profile before the first
+signing run:
+
+    security find-identity -v -p codesigning
+    xcrun notarytool store-credentials exfat-resize-notary
+
+Sign and notarize the archive into a separate output directory:
+
+    tools/sign-macos-binary.sh \
+        --identity "Developer ID Application: NAME (TEAMID)" \
+        --notary-profile exfat-resize-notary \
+        exfat-resize-X.Y.Z-macos-arm64.tar signed
+
+The helper validates the complete unsigned package before accessing the signing
+identity. It then signs only the CLI with the hardened runtime and a secure
+timestamp, submits a temporary ZIP to Apple, retrieves the notarization log,
+and creates the final `.tar.gz`. Because Apple does not support stapling a ticket
+to a standalone executable, the helper verifies the ticket with the online
+notarization check supported by `codesign`. The output directory receives the
+final archive and its notarization log. Upload only the archive to the draft
+GitHub Release, then approve the pending `macos-release` environment job.
+
+The approved job downloads the exact draft asset on a fresh macOS runner. It
+checks the GitHub asset digest, package version and contents, ARM64 architecture,
+deployment target, dependencies, Developer ID team, secure timestamp, hardened
+runtime, and online notarization ticket. It also exercises installation and
+uninstallation and performs an actual exFAT resize. The job never publishes the
+draft; publication remains a separate manual action after all checks pass.
 
 ## Creating a signed release tag
 

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -54,11 +54,12 @@ manually; the workflow removes it after constructing the final archive.
 
 The workflow creates or updates a draft release; it never modifies an already
 published release. If assembly or verification fails, use **Re-run failed jobs**
-to retain the uploaded executable. **Re-run all jobs** also reruns draft creation,
-which deletes every existing draft asset; upload the same signed executable again
-when the workflow returns to the approval. Neither case requires replacing the
-release tag. Review the generated notes and assets before publishing the draft
-manually.
+to retain and reuse the uploaded executable. **Re-run all jobs** rebuilds the
+unsigned archive and reruns draft creation, which deletes every existing draft
+asset. Download and verify the new workflow artifact, sign it again, and upload
+its new `.signed` executable when the workflow returns to the approval. Neither
+case requires replacing the release tag. Review the generated notes and assets
+before publishing the draft manually.
 
 The repository must have a protected GitHub environment named `macos-release`
 with the maintainer as a required reviewer. Do not enable prevention of
@@ -102,14 +103,15 @@ directory:
         exfat-resize-X.Y.Z-macos-arm64.tar.gz signed
 
 Before accessing the signing identity, the helper selectively extracts exactly
-one regular CLI entry and validates its version, architecture, deployment target,
-dependencies, and ad-hoc signature. It then signs the CLI with the hardened
-runtime and a secure timestamp, submits a temporary ZIP to Apple, retrieves the
-notarization log, and writes `exfat-resize-X.Y.Z-macos-arm64.signed` alongside
-that log. Because Apple does not support stapling a ticket to a standalone
-executable, the helper verifies the ticket with the online notarization check
-supported by `codesign`. Upload only the `.signed` executable to the draft GitHub
-Release, then approve the pending `macos-release` environment job.
+one regular CLI entry and validates the archive version, architecture, deployment
+target, dependencies, and ad-hoc signature without executing the downloaded CLI.
+It then signs the CLI with the hardened runtime and a secure timestamp, submits a
+temporary ZIP to Apple, retrieves the notarization log, and writes
+`exfat-resize-X.Y.Z-macos-arm64.signed` alongside that log. Because Apple does not
+support stapling a ticket to a standalone executable, the helper verifies the
+ticket with the online notarization check supported by `codesign`. Upload only the
+`.signed` executable to the draft GitHub Release, then approve the pending
+`macos-release` environment job.
 
 The approved job downloads that exact draft asset and its own tested unsigned
 archive on a fresh macOS runner. It verifies that removing and canonicalizing the

--- a/tests/package/macos-binary-test.sh
+++ b/tests/package/macos-binary-test.sh
@@ -4,9 +4,40 @@
 set -eu
 set -f
 
+usage() {
+	printf '%s\n' \
+		"usage: $0 [--developer-id-team TEAM_ID] MACOS_ARCHIVE SOURCE_DIRECTORY"
+}
+
+fail() {
+	echo "macos-binary-test: $*" >&2
+	exit 1
+}
+
+developer_id_team=
+while [ "$#" -gt 0 ]; do
+	case $1 in
+		--developer-id-team)
+			[ "$#" -ge 2 ] || fail "--developer-id-team requires a value"
+			developer_id_team=$2
+			shift 2
+			;;
+		--)
+			shift
+			break
+			;;
+		-*) fail "unknown option: $1" ;;
+		*) break ;;
+	esac
+done
+
 if [ "$#" -ne 2 ]; then
-	echo "usage: $0 MACOS_ARCHIVE SOURCE_DIRECTORY" >&2
+	usage >&2
 	exit 2
+fi
+if [ -n "$developer_id_team" ] &&
+	! printf '%s\n' "$developer_id_team" | grep -E '^[A-Z0-9]{10}$' >/dev/null; then
+	fail "invalid Developer ID team: $developer_id_team"
 fi
 
 archive=$1
@@ -34,6 +65,31 @@ build_version=$(sed -n '1p' "$source_directory/.tarball-version")
 package=exfat-resize-$build_version-macos-arm64
 if [ "$archive_name" != "$package.tar.gz" ]; then
 	echo "macOS archive and source build versions disagree" >&2
+	exit 1
+fi
+
+expected_entries=$(
+	printf '%s\n' \
+		"$package/" \
+		"$package/LICENSE" \
+		"$package/README.md" \
+		"$package/docs/" \
+		"$package/docs/TRANSACTION.md" \
+		"$package/exfat-resize" \
+		"$package/exfat-resize.8" \
+		"$package/install.sh" \
+		"$package/uninstall.sh" |
+		sort
+)
+actual_entries=$(LC_ALL=C tar -tf "$archive" | sort)
+if [ "$actual_entries" != "$expected_entries" ]; then
+	fail "macOS archive contains an unexpected entry set"
+fi
+unexpected_types=$(LC_ALL=C tar -tvf "$archive" |
+	awk 'substr($1, 1, 1) != "-" && substr($1, 1, 1) != "d" { print }')
+if [ -n "$unexpected_types" ]; then
+	echo "macOS archive contains an unexpected entry type:" >&2
+	printf '%s\n' "$unexpected_types" >&2
 	exit 1
 fi
 
@@ -106,14 +162,38 @@ if [ "$dependencies" != /usr/lib/libSystem.B.dylib ]; then
 	exit 1
 fi
 if ! codesign --verify --strict "$binary"; then
-	echo "archived CLI has an invalid ad-hoc signature" >&2
+	echo "archived CLI has an invalid signature" >&2
 	exit 1
 fi
-signature=$(codesign -dvv "$binary" 2>&1)
-if ! printf '%s\n' "$signature" | grep -Fx 'Signature=adhoc' >/dev/null; then
-	echo "archived CLI does not have an ad-hoc signature" >&2
-	printf '%s\n' "$signature" >&2
-	exit 1
+signature=$(codesign -dvvv "$binary" 2>&1)
+if [ -z "$developer_id_team" ]; then
+	if ! printf '%s\n' "$signature" | grep -Fx 'Signature=adhoc' >/dev/null; then
+		echo "archived CLI does not have an ad-hoc signature" >&2
+		printf '%s\n' "$signature" >&2
+		exit 1
+	fi
+	signature_description=ad-hoc
+else
+	authority=$(printf '%s\n' "$signature" | sed -n 's/^Authority=//p' | sed -n '1p')
+	team_identifier=$(printf '%s\n' "$signature" | sed -n 's/^TeamIdentifier=//p')
+	case $authority in
+		"Developer ID Application: "*) ;;
+		*) fail "CLI was not signed with a Developer ID Application certificate" ;;
+	esac
+	if [ "$team_identifier" != "$developer_id_team" ]; then
+		fail "unexpected Developer ID team: $team_identifier"
+	fi
+	if ! printf '%s\n' "$signature" | grep -E '^Timestamp=.' >/dev/null; then
+		fail "Developer ID signature does not have a secure timestamp"
+	fi
+	if ! printf '%s\n' "$signature" |
+		grep -E '^CodeDirectory .*\(.*runtime.*\)' >/dev/null; then
+		fail "Developer ID signature does not enable the hardened runtime"
+	fi
+	if ! codesign -vvvv -R=notarized --check-notarization "$binary"; then
+		fail "CLI does not satisfy Apple's notarized code requirement"
+	fi
+	signature_description="Developer ID team $team_identifier"
 fi
 
 DESTDIR=$temporary/install-root "$package_directory/install.sh"
@@ -132,6 +212,13 @@ fi
 if [ "$(find "$install_prefix" -type f | wc -l)" -ne 5 ]; then
 	echo "installer created an unexpected file set" >&2
 	exit 1
+fi
+if ! codesign --verify --strict "$installed_binary"; then
+	fail "installed CLI has an invalid signature"
+fi
+if [ -n "$developer_id_team" ] &&
+	! codesign -vvvv -R=notarized --check-notarization "$installed_binary"; then
+	fail "installed CLI does not satisfy Apple's notarized code requirement"
 fi
 
 touch "$install_prefix/bin/unrelated" "$install_prefix/share/man/man8/unrelated.8" \
@@ -156,3 +243,4 @@ done
 
 echo "macOS binary archive test: passed"
 echo "minimum macOS version: $minimum_macos"
+echo "signature: $signature_description"

--- a/tests/package/macos-binary-test.sh
+++ b/tests/package/macos-binary-test.sh
@@ -1,0 +1,158 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+set -f
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 MACOS_ARCHIVE SOURCE_DIRECTORY" >&2
+	exit 2
+fi
+
+archive=$1
+source_directory=$2
+archive_directory=$(CDPATH= cd -- "$(dirname "$archive")" && pwd)
+archive_name=${archive##*/}
+archive=$archive_directory/$archive_name
+temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-macos-test.XXXXXX")
+
+cleanup() {
+	rm -rf "$temporary"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+case $archive_name in
+	exfat-resize-*-macos-arm64.tar.gz) ;;
+	*)
+		echo "unexpected macOS archive name: $archive_name" >&2
+		exit 1
+		;;
+esac
+
+build_version=$(sed -n '1p' "$source_directory/.tarball-version")
+package=exfat-resize-$build_version-macos-arm64
+if [ "$archive_name" != "$package.tar.gz" ]; then
+	echo "macOS archive and source build versions disagree" >&2
+	exit 1
+fi
+
+mkdir -p "$temporary/extracted" "$temporary/install-root"
+tar -xzf "$archive" -C "$temporary/extracted"
+package_directory=$temporary/extracted/$package
+top_level=$(find "$temporary/extracted" -mindepth 1 -maxdepth 1 -exec basename {} \;)
+if [ "$top_level" != "$package" ] || [ ! -d "$package_directory" ]; then
+	echo "macOS archive has an unexpected top-level directory" >&2
+	exit 1
+fi
+expected=$(
+	printf '%s\n' LICENSE README.md docs exfat-resize exfat-resize.8 install.sh uninstall.sh |
+		sort
+)
+actual=$(find "$package_directory" -mindepth 1 -maxdepth 1 -exec basename {} \; | sort)
+if [ "$actual" != "$expected" ]; then
+	echo "macOS archive contains an unexpected file set" >&2
+	printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+	exit 1
+fi
+documentation=$(find "$package_directory/docs" -mindepth 1 -maxdepth 1 -exec basename {} \;)
+if [ "$documentation" != TRANSACTION.md ]; then
+	echo "macOS archive contains an unexpected documentation file set" >&2
+	exit 1
+fi
+if [ "$(stat -f '%Lp' "$package_directory/exfat-resize")" != 755 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/install.sh")" != 755 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/uninstall.sh")" != 755 ]; then
+	echo "macOS archive executable modes are incorrect" >&2
+	exit 1
+fi
+if [ "$(stat -f '%Lp' "$package_directory/exfat-resize.8")" != 644 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/LICENSE")" != 644 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/README.md")" != 644 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/docs/TRANSACTION.md")" != 644 ]; then
+	echo "macOS archive data-file modes are incorrect" >&2
+	exit 1
+fi
+
+binary=$package_directory/exfat-resize
+if [ "$("$binary" --version)" != "exfat-resize $build_version" ]; then
+	echo "archived CLI version is incorrect" >&2
+	exit 1
+fi
+if ! grep -F "exfat-resize $build_version" "$package_directory/exfat-resize.8" >/dev/null; then
+	echo "archived manual page has an incorrect version" >&2
+	exit 1
+fi
+cmp "$source_directory/LICENSE" "$package_directory/LICENSE"
+cmp "$source_directory/README.md" "$package_directory/README.md"
+cmp "$source_directory/docs/TRANSACTION.md" "$package_directory/docs/TRANSACTION.md"
+
+architectures=$(lipo -archs "$binary")
+if [ "$architectures" != arm64 ]; then
+	echo "archived CLI has an unexpected Mach-O architecture set: $architectures" >&2
+	exit 1
+fi
+build_info=$(xcrun vtool -show-build "$binary")
+minimum_macos=$(printf '%s\n' "$build_info" | awk '$1 == "minos" { print $2; exit }')
+if [ "$minimum_macos" != 11.0 ]; then
+	echo "archived CLI has an unexpected minimum macOS version: $minimum_macos" >&2
+	exit 1
+fi
+dependencies=$(LC_ALL=C otool -L "$binary" |
+	sed -n '2,$s/^[[:space:]]*\([^[:space:]]*\).*/\1/p')
+if [ "$dependencies" != /usr/lib/libSystem.B.dylib ]; then
+	echo "archived CLI has an unexpected dynamic-library dependency set:" >&2
+	printf '%s\n' "$dependencies" >&2
+	exit 1
+fi
+if ! codesign --verify --strict "$binary"; then
+	echo "archived CLI has an invalid ad-hoc signature" >&2
+	exit 1
+fi
+signature=$(codesign -dvv "$binary" 2>&1)
+if ! printf '%s\n' "$signature" | grep -Fx 'Signature=adhoc' >/dev/null; then
+	echo "archived CLI does not have an ad-hoc signature" >&2
+	printf '%s\n' "$signature" >&2
+	exit 1
+fi
+
+DESTDIR=$temporary/install-root "$package_directory/install.sh"
+install_prefix=$temporary/install-root/usr/local
+installed_binary=$install_prefix/bin/exfat-resize
+installed_manual=$install_prefix/share/man/man8/exfat-resize.8
+installed_license=$install_prefix/share/doc/exfat-resize/LICENSE
+installed_readme=$install_prefix/share/doc/exfat-resize/README.md
+installed_transaction=$install_prefix/share/doc/exfat-resize/docs/TRANSACTION.md
+if [ "$("$installed_binary" --version)" != "exfat-resize $build_version" ] ||
+	[ ! -f "$installed_manual" ] || [ ! -f "$installed_license" ] ||
+	[ ! -f "$installed_readme" ] || [ ! -f "$installed_transaction" ]; then
+	echo "installed macOS archive is incomplete" >&2
+	exit 1
+fi
+if [ "$(find "$install_prefix" -type f | wc -l)" -ne 5 ]; then
+	echo "installer created an unexpected file set" >&2
+	exit 1
+fi
+
+touch "$install_prefix/bin/unrelated" "$install_prefix/share/man/man8/unrelated.8" \
+	"$install_prefix/share/doc/exfat-resize/unrelated" \
+	"$install_prefix/share/doc/exfat-resize/docs/unrelated"
+DESTDIR=$temporary/install-root "$package_directory/uninstall.sh"
+if [ -e "$installed_binary" ] || [ -e "$installed_manual" ] || [ -e "$installed_license" ] ||
+	[ -e "$installed_readme" ] || [ -e "$installed_transaction" ]; then
+	echo "uninstaller left an installed project file behind" >&2
+	exit 1
+fi
+for unrelated in "$install_prefix/bin/unrelated" "$install_prefix/share/man/man8/unrelated.8" \
+	"$install_prefix/share/doc/exfat-resize/unrelated" \
+	"$install_prefix/share/doc/exfat-resize/docs/unrelated"; do
+	if [ ! -f "$unrelated" ]; then
+		echo "uninstaller removed an unrelated file: $unrelated" >&2
+		exit 1
+	fi
+done
+
+"$source_directory/tests/cli/grow-image.sh" "$binary"
+
+echo "macOS binary archive test: passed"
+echo "minimum macOS version: $minimum_macos"

--- a/tests/package/macos-binary-test.sh
+++ b/tests/package/macos-binary-test.sh
@@ -166,6 +166,14 @@ if ! codesign --verify --strict "$binary"; then
 	exit 1
 fi
 signature=$(codesign -dvvv "$binary" 2>&1)
+identifier=$(printf '%s\n' "$signature" | sed -n 's/^Identifier=//p')
+if [ "$identifier" != exfat-resize ]; then
+	fail "CLI has an unexpected code-signing identifier: $identifier"
+fi
+entitlements=$(codesign -d --entitlements - "$binary" 2>/dev/null)
+if [ -n "$entitlements" ]; then
+	fail "CLI has unexpected code-signing entitlements"
+fi
 if [ -z "$developer_id_team" ]; then
 	if ! printf '%s\n' "$signature" | grep -Fx 'Signature=adhoc' >/dev/null; then
 		echo "archived CLI does not have an ad-hoc signature" >&2
@@ -186,9 +194,8 @@ else
 	if ! printf '%s\n' "$signature" | grep -E '^Timestamp=.' >/dev/null; then
 		fail "Developer ID signature does not have a secure timestamp"
 	fi
-	if ! printf '%s\n' "$signature" |
-		grep -E '^CodeDirectory .*\(.*runtime.*\)' >/dev/null; then
-		fail "Developer ID signature does not enable the hardened runtime"
+	if ! printf '%s\n' "$signature" | grep -F 'flags=0x10000(runtime)' >/dev/null; then
+		fail "Developer ID signature does not have only the hardened-runtime flag"
 	fi
 	if ! codesign -vvvv -R=notarized --check-notarization "$binary"; then
 		fail "CLI does not satisfy Apple's notarized code requirement"

--- a/tools/assemble-macos-binary.sh
+++ b/tools/assemble-macos-binary.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+set -f
+
+usage() {
+	echo "usage: $0 UNSIGNED_ARCHIVE SIGNED_EXECUTABLE OUTPUT_DIRECTORY"
+}
+
+fail() {
+	echo "assemble-macos-binary: $*" >&2
+	exit 1
+}
+
+if [ "$#" -ne 3 ]; then
+	usage >&2
+	exit 2
+fi
+if [ "$(uname -s)" != Darwin ] || [ "$(uname -m)" != arm64 ]; then
+	fail "assembly requires macOS ARM64"
+fi
+
+archive_input=$1
+archive_directory=$(CDPATH= cd -- "$(dirname "$archive_input")" && pwd)
+archive_name=${archive_input##*/}
+archive=$archive_directory/$archive_name
+[ -f "$archive" ] || fail "unsigned archive does not exist: $archive"
+
+case $archive_name in
+	exfat-resize-*-macos-arm64.tar.gz) package=${archive_name%.tar.gz} ;;
+	*) fail "unexpected unsigned archive name: $archive_name" ;;
+esac
+
+signed_input=$2
+signed_directory=$(CDPATH= cd -- "$(dirname "$signed_input")" && pwd)
+signed_name=${signed_input##*/}
+signed_binary=$signed_directory/$signed_name
+[ -f "$signed_binary" ] || fail "signed executable does not exist: $signed_binary"
+[ "$signed_name" = "$package.signed" ] || fail "unexpected signed executable name: $signed_name"
+
+output_directory_input=$3
+mkdir -p "$output_directory_input"
+output_directory=$(CDPATH= cd -- "$output_directory_input" && pwd)
+output_archive=$output_directory/$archive_name
+[ "$output_archive" != "$archive" ] || fail "output would overwrite the unsigned input"
+[ ! -e "$output_archive" ] || fail "output archive already exists: $output_archive"
+
+temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-macos-assemble.XXXXXX")
+cleanup() {
+	rm -rf "$temporary"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir "$temporary/extracted"
+COPYFILE_DISABLE=1 tar -xzf "$archive" -C "$temporary/extracted"
+package_directory=$temporary/extracted/$package
+unsigned_binary=$package_directory/exfat-resize
+if [ ! -d "$package_directory" ] || [ ! -f "$unsigned_binary" ]; then
+	fail "unsigned archive extraction is incomplete"
+fi
+codesign --verify --strict "$unsigned_binary" || fail "unsigned CLI signature is invalid"
+codesign --verify --strict "$signed_binary" || fail "signed CLI signature is invalid"
+
+unsigned_canonical=$temporary/unsigned-canonical
+signed_canonical=$temporary/signed-canonical
+install -m 0755 "$unsigned_binary" "$unsigned_canonical"
+install -m 0755 "$signed_binary" "$signed_canonical"
+codesign --remove-signature "$unsigned_canonical"
+codesign --remove-signature "$signed_canonical"
+codesign --force --identifier exfat-resize --options runtime --sign - "$unsigned_canonical"
+codesign --force --identifier exfat-resize --options runtime --sign - "$signed_canonical"
+if ! cmp "$unsigned_canonical" "$signed_canonical"; then
+	fail "signed CLI does not match the tested unsigned CLI"
+fi
+
+install -m 0755 "$signed_binary" "$unsigned_binary"
+candidate_archive=$temporary/$archive_name
+COPYFILE_DISABLE=1 tar -czf "$candidate_archive" -C "$temporary/extracted" "$package"
+install -m 0644 "$candidate_archive" "$output_archive"
+
+output_sha256=$(shasum -a 256 "$output_archive" | awk '{ print $1 }')
+printf 'assembled signed macOS archive: %s\n' "$output_archive"
+printf 'output archive SHA-256: %s\n' "$output_sha256"

--- a/tools/build-macos-binary.sh
+++ b/tools/build-macos-binary.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+set -f
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 SOURCE_DIRECTORY OUTPUT_DIRECTORY" >&2
+	exit 2
+fi
+
+source_directory=$1
+output_directory=$2
+cmake_command=${CMAKE:-cmake}
+deployment_target=11.0
+temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-macos-build.XXXXXX")
+
+cleanup() {
+	rm -rf "$temporary"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+if [ "$(uname -s)" != Darwin ] || [ "$(uname -m)" != arm64 ]; then
+	echo "macOS binary archives must be built on macOS ARM64" >&2
+	exit 1
+fi
+if [ ! -d "$source_directory" ]; then
+	echo "source directory does not exist: $source_directory" >&2
+	exit 1
+fi
+source_directory=$(CDPATH= cd -- "$source_directory" && pwd)
+if [ -e "$source_directory/.git" ]; then
+	echo "source directory must be an extracted, Git-free source archive" >&2
+	exit 1
+fi
+if [ ! -f "$source_directory/VERSION" ] || [ ! -f "$source_directory/.tarball-version" ]; then
+	echo "source archive version metadata is missing" >&2
+	exit 1
+fi
+
+package_version=$(sed -n '1p' "$source_directory/VERSION")
+build_version=$(sed -n '1p' "$source_directory/.tarball-version")
+if ! printf '%s\n' "$package_version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' >/dev/null; then
+	echo "invalid package version: $package_version" >&2
+	exit 1
+fi
+if ! printf '%s\n' "$build_version" | grep -E '^[0-9A-Za-z][0-9A-Za-z.+-]*$' >/dev/null; then
+	echo "invalid build version: $build_version" >&2
+	exit 1
+fi
+case $build_version in
+	"$package_version" | "$package_version"-*) ;;
+	*)
+		echo "package and build versions disagree" >&2
+		exit 1
+		;;
+esac
+if [ "${source_directory##*/}" != "exfat-resize-$build_version" ]; then
+	echo "source directory and build versions disagree" >&2
+	exit 1
+fi
+
+mkdir -p "$temporary/build" "$temporary/stage" "$output_directory"
+"$cmake_command" -S "$source_directory" -B "$temporary/build" \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_OSX_ARCHITECTURES=arm64 \
+	-DCMAKE_OSX_DEPLOYMENT_TARGET="$deployment_target" \
+	-DEXFAT_RESIZE_BUILD_CLI=ON \
+	-DEXFAT_RESIZE_BUILD_TESTS=OFF
+"$cmake_command" --build "$temporary/build" --parallel --target exfat-resize
+"$cmake_command" --install "$temporary/build" --component Runtime \
+	--prefix "$temporary/stage/usr/local" --strip
+
+binary=$temporary/stage/usr/local/bin/exfat-resize
+manual=$temporary/stage/usr/local/share/man/man8/exfat-resize.8
+documentation=$temporary/stage/usr/local/share/doc/exfat_resize
+license=$documentation/LICENSE
+readme=$documentation/README.md
+transaction=$documentation/docs/TRANSACTION.md
+if [ ! -x "$binary" ] || [ ! -f "$manual" ] || [ ! -f "$license" ] ||
+	[ ! -f "$readme" ] || [ ! -f "$transaction" ]; then
+	echo "CMake runtime installation is incomplete" >&2
+	exit 1
+fi
+if [ "$("$binary" --version)" != "exfat-resize $build_version" ]; then
+	echo "built CLI version does not match the source archive" >&2
+	exit 1
+fi
+
+architectures=$(lipo -archs "$binary")
+if [ "$architectures" != arm64 ]; then
+	echo "unexpected Mach-O architecture set: $architectures" >&2
+	exit 1
+fi
+build_info=$(xcrun vtool -show-build "$binary")
+minimum_macos=$(printf '%s\n' "$build_info" | awk '$1 == "minos" { print $2; exit }')
+if [ "$minimum_macos" != "$deployment_target" ]; then
+	echo "unexpected minimum macOS version: $minimum_macos" >&2
+	exit 1
+fi
+dependencies=$(LC_ALL=C otool -L "$binary" |
+	sed -n '2,$s/^[[:space:]]*\([^[:space:]]*\).*/\1/p')
+if [ "$dependencies" != /usr/lib/libSystem.B.dylib ]; then
+	echo "unexpected dynamic-library dependency set:" >&2
+	printf '%s\n' "$dependencies" >&2
+	exit 1
+fi
+if ! codesign --verify --strict "$binary"; then
+	echo "built CLI has an invalid ad-hoc signature" >&2
+	exit 1
+fi
+signature=$(codesign -dvv "$binary" 2>&1)
+if ! printf '%s\n' "$signature" | grep -Fx 'Signature=adhoc' >/dev/null; then
+	echo "built CLI does not have an ad-hoc signature" >&2
+	printf '%s\n' "$signature" >&2
+	exit 1
+fi
+
+package=exfat-resize-$build_version-macos-arm64
+package_directory=$temporary/$package
+mkdir -p "$package_directory/docs"
+install -m 0755 "$binary" "$package_directory/exfat-resize"
+install -m 0644 "$manual" "$package_directory/exfat-resize.8"
+install -m 0644 "$license" "$package_directory/LICENSE"
+install -m 0644 "$readme" "$package_directory/README.md"
+install -m 0644 "$transaction" "$package_directory/docs/TRANSACTION.md"
+install -m 0755 "$source_directory/packaging/linux/install.sh" "$package_directory/install.sh"
+install -m 0755 "$source_directory/packaging/linux/uninstall.sh" \
+	"$package_directory/uninstall.sh"
+
+archive=$package.tar.gz
+COPYFILE_DISABLE=1 tar -czf "$output_directory/$archive" -C "$temporary" "$package"
+
+echo "built $output_directory/$archive"
+echo "minimum macOS version: $minimum_macos"

--- a/tools/sign-macos-binary.sh
+++ b/tools/sign-macos-binary.sh
@@ -71,17 +71,10 @@ archive=$archive_directory/$input_name
 [ -f "$archive" ] || fail "archive does not exist: $archive"
 
 case $input_name in
-	exfat-resize-*-macos-arm64.tar.gz)
-		package=${input_name%.tar.gz}
-		gzip -t "$archive"
-		content_sha256=$(gzip -dc "$archive" | shasum -a 256 | awk '{ print $1 }')
-		;;
-	exfat-resize-*-macos-arm64.tar)
-		package=${input_name%.tar}
-		content_sha256=$(shasum -a 256 "$archive" | awk '{ print $1 }')
-		;;
+	exfat-resize-*-macos-arm64.tar.gz) package=${input_name%.tar.gz} ;;
 	*) fail "unexpected unsigned archive name: $input_name" ;;
 esac
+gzip -t "$archive"
 
 tool_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 package_version=$(sed -n '1p' "$tool_root/VERSION")
@@ -100,32 +93,14 @@ esac
 
 input_sha256=$(shasum -a 256 "$archive" | awk '{ print $1 }')
 printf 'input archive SHA-256: %s\n' "$input_sha256"
-printf 'uncompressed tar SHA-256: %s\n' "$content_sha256"
 
-expected_entries=$(
-	printf '%s\n' \
-		"$package/" \
-		"$package/LICENSE" \
-		"$package/README.md" \
-		"$package/docs/" \
-		"$package/docs/TRANSACTION.md" \
-		"$package/exfat-resize" \
-		"$package/exfat-resize.8" \
-		"$package/install.sh" \
-		"$package/uninstall.sh" |
-		sort
-)
-actual_entries=$(LC_ALL=C tar -tf "$archive" | sort)
-if [ "$actual_entries" != "$expected_entries" ]; then
-	fail "archive contains an unexpected file set"
-fi
-unexpected_types=$(LC_ALL=C tar -tvf "$archive" |
-	awk 'substr($1, 1, 1) != "-" && substr($1, 1, 1) != "d" { print }')
-if [ -n "$unexpected_types" ]; then
-	echo "archive contains an unexpected entry type:" >&2
-	printf '%s\n' "$unexpected_types" >&2
-	exit 1
-fi
+binary_entry=$package/exfat-resize
+binary_entry_count=$(LC_ALL=C tar -tf "$archive" |
+	awk -v expected="$binary_entry" '$0 == expected { count++ } END { print count + 0 }')
+[ "$binary_entry_count" -eq 1 ] || fail "archive must contain exactly one $binary_entry"
+binary_type=$(LC_ALL=C tar -tvf "$archive" "$binary_entry" |
+	awk 'NR == 1 { print substr($1, 1, 1) }')
+[ "$binary_type" = - ] || fail "archived CLI is not a regular file"
 
 temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-macos-sign.XXXXXX")
 cleanup() {
@@ -133,30 +108,9 @@ cleanup() {
 }
 trap cleanup EXIT HUP INT TERM
 
-mkdir "$temporary/extracted"
-COPYFILE_DISABLE=1 tar -xf "$archive" -C "$temporary/extracted"
-package_directory=$temporary/extracted/$package
-binary=$package_directory/exfat-resize
-if [ ! -d "$package_directory" ] || [ ! -x "$binary" ]; then
-	fail "archive extraction is incomplete"
-fi
-if [ "$(stat -f '%Lp' "$binary")" != 755 ] ||
-	[ "$(stat -f '%Lp' "$package_directory/install.sh")" != 755 ] ||
-	[ "$(stat -f '%Lp' "$package_directory/uninstall.sh")" != 755 ]; then
-	fail "archive executable modes are incorrect"
-fi
-if [ "$(stat -f '%Lp' "$package_directory/exfat-resize.8")" != 644 ] ||
-	[ "$(stat -f '%Lp' "$package_directory/LICENSE")" != 644 ] ||
-	[ "$(stat -f '%Lp' "$package_directory/README.md")" != 644 ] ||
-	[ "$(stat -f '%Lp' "$package_directory/docs/TRANSACTION.md")" != 644 ]; then
-	fail "archive data-file modes are incorrect"
-fi
-
-cmp "$tool_root/LICENSE" "$package_directory/LICENSE"
-cmp "$tool_root/README.md" "$package_directory/README.md"
-cmp "$tool_root/docs/TRANSACTION.md" "$package_directory/docs/TRANSACTION.md"
-cmp "$tool_root/packaging/linux/install.sh" "$package_directory/install.sh"
-cmp "$tool_root/packaging/linux/uninstall.sh" "$package_directory/uninstall.sh"
+binary=$temporary/exfat-resize
+COPYFILE_DISABLE=1 tar -xOzf "$archive" "$binary_entry" >"$binary"
+chmod 0755 "$binary"
 
 if [ "$("$binary" --version)" != "exfat-resize $build_version" ]; then
 	fail "archived CLI version is incorrect"
@@ -190,11 +144,10 @@ fi
 output_directory_input=$2
 mkdir -p "$output_directory_input"
 output_directory=$(CDPATH= cd -- "$output_directory_input" && pwd)
-output_name=$package.tar.gz
-output_archive=$output_directory/$output_name
+output_name=$package.signed
+output_binary=$output_directory/$output_name
 output_log=$output_directory/$output_name.notarization.json
-[ "$output_archive" != "$archive" ] || fail "output would overwrite the unsigned input"
-[ ! -e "$output_archive" ] || fail "output archive already exists: $output_archive"
+[ ! -e "$output_binary" ] || fail "output executable already exists: $output_binary"
 [ ! -e "$output_log" ] || fail "notarization log already exists: $output_log"
 
 identities=$(security find-identity -v -p codesigning)
@@ -203,11 +156,14 @@ if ! printf '%s\n' "$identities" | grep -F "$identity" >/dev/null; then
 	fail "code-signing identity is not available: $identity"
 fi
 
-codesign --force --options runtime --timestamp --sign "$identity" "$binary"
+codesign --force --identifier exfat-resize --options runtime --timestamp \
+	--sign "$identity" "$binary"
 codesign --verify --strict --verbose=2 "$binary"
 signing_details=$(codesign -dvvv "$binary" 2>&1)
+identifier=$(printf '%s\n' "$signing_details" | sed -n 's/^Identifier=//p')
 authority=$(printf '%s\n' "$signing_details" | sed -n 's/^Authority=//p' | sed -n '1p')
 team_identifier=$(printf '%s\n' "$signing_details" | sed -n 's/^TeamIdentifier=//p')
+[ "$identifier" = exfat-resize ] || fail "signed CLI has an unexpected identifier: $identifier"
 case $authority in
 	"Developer ID Application: "*) ;;
 	*) fail "CLI was not signed with a Developer ID Application certificate" ;;
@@ -218,15 +174,19 @@ fi
 if ! printf '%s\n' "$signing_details" | grep -E '^Timestamp=.' >/dev/null; then
 	fail "signed CLI does not have a secure timestamp"
 fi
-if ! printf '%s\n' "$signing_details" | grep -E '^CodeDirectory .*\(.*runtime.*\)' >/dev/null; then
-	fail "signed CLI does not enable the hardened runtime"
+if ! printf '%s\n' "$signing_details" | grep -F 'flags=0x10000(runtime)' >/dev/null; then
+	fail "signed CLI does not have only the hardened-runtime code-signing flag"
+fi
+entitlements=$(codesign -d --entitlements - "$binary" 2>/dev/null)
+if [ -n "$entitlements" ]; then
+	fail "signed CLI has unexpected entitlements"
 fi
 if [ "$("$binary" --version)" != "exfat-resize $build_version" ]; then
 	fail "signed CLI version is incorrect"
 fi
 
 notary_archive=$temporary/$package-notarization.zip
-COPYFILE_DISABLE=1 ditto -c -k --keepParent "$package_directory" "$notary_archive"
+COPYFILE_DISABLE=1 ditto -c -k --keepParent "$binary" "$notary_archive"
 submission=$temporary/notarization-submission.json
 notary_exit=0
 xcrun notarytool submit "$notary_archive" \
@@ -247,33 +207,23 @@ fi
 [ -n "$submission_id" ] || fail "notarization response did not contain a submission ID"
 [ "$notary_status" = Accepted ] || fail "notarization status is $notary_status"
 
-candidate_archive=$temporary/$output_name
-COPYFILE_DISABLE=1 tar -czf "$candidate_archive" -C "$temporary/extracted" "$package"
-
-mkdir "$temporary/final-check"
-COPYFILE_DISABLE=1 tar -xzf "$candidate_archive" -C "$temporary/final-check"
-final_binary=$temporary/final-check/$package/exfat-resize
-codesign --verify --strict --verbose=2 "$final_binary"
-if [ "$("$final_binary" --version)" != "exfat-resize $build_version" ]; then
-	fail "final archived CLI version is incorrect"
-fi
 notarization_attempt=1
 while ! notarization_check=$(codesign -vvvv -R=notarized \
-	--check-notarization "$final_binary" 2>&1); do
+	--check-notarization "$binary" 2>&1); do
 	if [ "$notarization_attempt" -ge 6 ]; then
 		printf '%s\n' "$notarization_check" >&2
-		fail "notarization ticket is unavailable for the final CLI"
+		fail "notarization ticket is unavailable for the signed CLI"
 	fi
 	notarization_attempt=$((notarization_attempt + 1))
 	sleep 5
 done
 printf '%s\n' "$notarization_check"
 
-install -m 0644 "$candidate_archive" "$output_archive"
+install -m 0755 "$binary" "$output_binary"
 install -m 0644 "$notary_log" "$output_log"
-output_sha256=$(shasum -a 256 "$output_archive" | awk '{ print $1 }')
-printf 'built signed and notarized archive: %s\n' "$output_archive"
+output_sha256=$(shasum -a 256 "$output_binary" | awk '{ print $1 }')
+printf 'built signed and notarized executable: %s\n' "$output_binary"
 printf 'notarization log: %s\n' "$output_log"
 printf 'Developer ID authority: %s\n' "$authority"
 printf 'Team Identifier: %s\n' "$team_identifier"
-printf 'output archive SHA-256: %s\n' "$output_sha256"
+printf 'output executable SHA-256: %s\n' "$output_sha256"

--- a/tools/sign-macos-binary.sh
+++ b/tools/sign-macos-binary.sh
@@ -60,8 +60,8 @@ else
 	fi
 fi
 
-if [ "$(uname -s)" != Darwin ] || [ "$(uname -m)" != arm64 ]; then
-	fail "signing requires macOS ARM64"
+if [ "$(uname -s)" != Darwin ]; then
+	fail "signing requires macOS"
 fi
 
 input_archive=$1
@@ -112,10 +112,6 @@ binary=$temporary/exfat-resize
 COPYFILE_DISABLE=1 tar -xOzf "$archive" "$binary_entry" >"$binary"
 chmod 0755 "$binary"
 
-if [ "$("$binary" --version)" != "exfat-resize $build_version" ]; then
-	fail "archived CLI version is incorrect"
-fi
-"$binary" --help >/dev/null
 architectures=$(lipo -archs "$binary")
 [ "$architectures" = arm64 ] || fail "unexpected Mach-O architecture set: $architectures"
 build_info=$(xcrun vtool -show-build "$binary")
@@ -181,10 +177,6 @@ entitlements=$(codesign -d --entitlements - "$binary" 2>/dev/null)
 if [ -n "$entitlements" ]; then
 	fail "signed CLI has unexpected entitlements"
 fi
-if [ "$("$binary" --version)" != "exfat-resize $build_version" ]; then
-	fail "signed CLI version is incorrect"
-fi
-
 notary_archive=$temporary/$package-notarization.zip
 COPYFILE_DISABLE=1 ditto -c -k --keepParent "$binary" "$notary_archive"
 submission=$temporary/notarization-submission.json

--- a/tools/sign-macos-binary.sh
+++ b/tools/sign-macos-binary.sh
@@ -1,0 +1,279 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+set -f
+
+usage() {
+	printf '%s\n' \
+		"usage: $0 --check UNSIGNED_ARCHIVE" \
+		"       $0 --identity IDENTITY --notary-profile PROFILE \\" \
+		"           UNSIGNED_ARCHIVE OUTPUT_DIRECTORY"
+}
+
+fail() {
+	echo "sign-macos-binary: $*" >&2
+	exit 1
+}
+
+check_only=0
+identity=
+notary_profile=
+while [ "$#" -gt 0 ]; do
+	case $1 in
+		--check)
+			check_only=1
+			shift
+			;;
+		--identity)
+			[ "$#" -ge 2 ] || fail "--identity requires a value"
+			identity=$2
+			shift 2
+			;;
+		--notary-profile)
+			[ "$#" -ge 2 ] || fail "--notary-profile requires a value"
+			notary_profile=$2
+			shift 2
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		--)
+			shift
+			break
+			;;
+		-*) fail "unknown option: $1" ;;
+		*) break ;;
+	esac
+done
+
+if [ "$check_only" -eq 1 ]; then
+	if [ "$#" -ne 1 ] || [ -n "$identity" ] || [ -n "$notary_profile" ]; then
+		usage >&2
+		exit 2
+	fi
+else
+	if [ "$#" -ne 2 ] || [ -z "$identity" ] || [ -z "$notary_profile" ]; then
+		usage >&2
+		exit 2
+	fi
+fi
+
+if [ "$(uname -s)" != Darwin ] || [ "$(uname -m)" != arm64 ]; then
+	fail "signing requires macOS ARM64"
+fi
+
+input_archive=$1
+archive_directory=$(CDPATH= cd -- "$(dirname "$input_archive")" && pwd)
+input_name=${input_archive##*/}
+archive=$archive_directory/$input_name
+[ -f "$archive" ] || fail "archive does not exist: $archive"
+
+case $input_name in
+	exfat-resize-*-macos-arm64.tar.gz)
+		package=${input_name%.tar.gz}
+		gzip -t "$archive"
+		content_sha256=$(gzip -dc "$archive" | shasum -a 256 | awk '{ print $1 }')
+		;;
+	exfat-resize-*-macos-arm64.tar)
+		package=${input_name%.tar}
+		content_sha256=$(shasum -a 256 "$archive" | awk '{ print $1 }')
+		;;
+	*) fail "unexpected unsigned archive name: $input_name" ;;
+esac
+
+tool_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+package_version=$(sed -n '1p' "$tool_root/VERSION")
+build_version=${package#exfat-resize-}
+build_version=${build_version%-macos-arm64}
+if ! printf '%s\n' "$package_version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' >/dev/null; then
+	fail "invalid package version: $package_version"
+fi
+if ! printf '%s\n' "$build_version" | grep -E '^[0-9A-Za-z][0-9A-Za-z.+-]*$' >/dev/null; then
+	fail "invalid build version: $build_version"
+fi
+case $build_version in
+	"$package_version" | "$package_version"-*) ;;
+	*) fail "archive and checkout package versions disagree" ;;
+esac
+
+input_sha256=$(shasum -a 256 "$archive" | awk '{ print $1 }')
+printf 'input archive SHA-256: %s\n' "$input_sha256"
+printf 'uncompressed tar SHA-256: %s\n' "$content_sha256"
+
+expected_entries=$(
+	printf '%s\n' \
+		"$package/" \
+		"$package/LICENSE" \
+		"$package/README.md" \
+		"$package/docs/" \
+		"$package/docs/TRANSACTION.md" \
+		"$package/exfat-resize" \
+		"$package/exfat-resize.8" \
+		"$package/install.sh" \
+		"$package/uninstall.sh" |
+		sort
+)
+actual_entries=$(LC_ALL=C tar -tf "$archive" | sort)
+if [ "$actual_entries" != "$expected_entries" ]; then
+	fail "archive contains an unexpected file set"
+fi
+unexpected_types=$(LC_ALL=C tar -tvf "$archive" |
+	awk 'substr($1, 1, 1) != "-" && substr($1, 1, 1) != "d" { print }')
+if [ -n "$unexpected_types" ]; then
+	echo "archive contains an unexpected entry type:" >&2
+	printf '%s\n' "$unexpected_types" >&2
+	exit 1
+fi
+
+temporary=$(mktemp -d "${TMPDIR:-/tmp}/exfat-resize-macos-sign.XXXXXX")
+cleanup() {
+	rm -rf "$temporary"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir "$temporary/extracted"
+COPYFILE_DISABLE=1 tar -xf "$archive" -C "$temporary/extracted"
+package_directory=$temporary/extracted/$package
+binary=$package_directory/exfat-resize
+if [ ! -d "$package_directory" ] || [ ! -x "$binary" ]; then
+	fail "archive extraction is incomplete"
+fi
+if [ "$(stat -f '%Lp' "$binary")" != 755 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/install.sh")" != 755 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/uninstall.sh")" != 755 ]; then
+	fail "archive executable modes are incorrect"
+fi
+if [ "$(stat -f '%Lp' "$package_directory/exfat-resize.8")" != 644 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/LICENSE")" != 644 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/README.md")" != 644 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/docs/TRANSACTION.md")" != 644 ]; then
+	fail "archive data-file modes are incorrect"
+fi
+
+cmp "$tool_root/LICENSE" "$package_directory/LICENSE"
+cmp "$tool_root/README.md" "$package_directory/README.md"
+cmp "$tool_root/docs/TRANSACTION.md" "$package_directory/docs/TRANSACTION.md"
+cmp "$tool_root/packaging/linux/install.sh" "$package_directory/install.sh"
+cmp "$tool_root/packaging/linux/uninstall.sh" "$package_directory/uninstall.sh"
+
+if [ "$("$binary" --version)" != "exfat-resize $build_version" ]; then
+	fail "archived CLI version is incorrect"
+fi
+"$binary" --help >/dev/null
+architectures=$(lipo -archs "$binary")
+[ "$architectures" = arm64 ] || fail "unexpected Mach-O architecture set: $architectures"
+build_info=$(xcrun vtool -show-build "$binary")
+minimum_macos=$(printf '%s\n' "$build_info" | awk '$1 == "minos" { print $2; exit }')
+[ "$minimum_macos" = 11.0 ] || fail "unexpected minimum macOS version: $minimum_macos"
+dependencies=$(LC_ALL=C otool -L "$binary" |
+	sed -n '2,$s/^[[:space:]]*\([^[:space:]]*\).*/\1/p')
+if [ "$dependencies" != /usr/lib/libSystem.B.dylib ]; then
+	echo "unexpected dynamic-library dependency set:" >&2
+	printf '%s\n' "$dependencies" >&2
+	exit 1
+fi
+codesign --verify --strict "$binary" || fail "archived CLI has an invalid ad-hoc signature"
+signature=$(codesign -dvv "$binary" 2>&1)
+if ! printf '%s\n' "$signature" | grep -Fx 'Signature=adhoc' >/dev/null; then
+	fail "archived CLI does not have the expected ad-hoc signature"
+fi
+
+printf 'validated unsigned archive: %s\n' "$input_name"
+printf 'build version: %s\n' "$build_version"
+printf 'minimum macOS version: %s\n' "$minimum_macos"
+if [ "$check_only" -eq 1 ]; then
+	exit 0
+fi
+
+output_directory_input=$2
+mkdir -p "$output_directory_input"
+output_directory=$(CDPATH= cd -- "$output_directory_input" && pwd)
+output_name=$package.tar.gz
+output_archive=$output_directory/$output_name
+output_log=$output_directory/$output_name.notarization.json
+[ "$output_archive" != "$archive" ] || fail "output would overwrite the unsigned input"
+[ ! -e "$output_archive" ] || fail "output archive already exists: $output_archive"
+[ ! -e "$output_log" ] || fail "notarization log already exists: $output_log"
+
+identities=$(security find-identity -v -p codesigning)
+if ! printf '%s\n' "$identities" | grep -F "$identity" >/dev/null; then
+	echo "$identities" >&2
+	fail "code-signing identity is not available: $identity"
+fi
+
+codesign --force --options runtime --timestamp --sign "$identity" "$binary"
+codesign --verify --strict --verbose=2 "$binary"
+signing_details=$(codesign -dvvv "$binary" 2>&1)
+authority=$(printf '%s\n' "$signing_details" | sed -n 's/^Authority=//p' | sed -n '1p')
+team_identifier=$(printf '%s\n' "$signing_details" | sed -n 's/^TeamIdentifier=//p')
+case $authority in
+	"Developer ID Application: "*) ;;
+	*) fail "CLI was not signed with a Developer ID Application certificate" ;;
+esac
+if ! printf '%s\n' "$team_identifier" | grep -E '^[A-Z0-9]{10}$' >/dev/null; then
+	fail "signed CLI has an invalid Team Identifier: $team_identifier"
+fi
+if ! printf '%s\n' "$signing_details" | grep -E '^Timestamp=.' >/dev/null; then
+	fail "signed CLI does not have a secure timestamp"
+fi
+if ! printf '%s\n' "$signing_details" | grep -E '^CodeDirectory .*\(.*runtime.*\)' >/dev/null; then
+	fail "signed CLI does not enable the hardened runtime"
+fi
+if [ "$("$binary" --version)" != "exfat-resize $build_version" ]; then
+	fail "signed CLI version is incorrect"
+fi
+
+notary_archive=$temporary/$package-notarization.zip
+COPYFILE_DISABLE=1 ditto -c -k --keepParent "$package_directory" "$notary_archive"
+submission=$temporary/notarization-submission.json
+notary_exit=0
+xcrun notarytool submit "$notary_archive" \
+	--keychain-profile "$notary_profile" --wait --output-format json >"$submission" ||
+	notary_exit=$?
+cat "$submission"
+submission_id=$(plutil -extract id raw -o - "$submission" 2>/dev/null || true)
+notary_status=$(plutil -extract status raw -o - "$submission" 2>/dev/null || true)
+notary_log=$temporary/notarization-log.json
+if [ -n "$submission_id" ] && [ -n "$notary_status" ]; then
+	if ! xcrun notarytool log --keychain-profile "$notary_profile" \
+		"$submission_id" "$notary_log"; then
+		fail "could not retrieve notarization log for $submission_id"
+	fi
+	cat "$notary_log"
+fi
+[ "$notary_exit" -eq 0 ] || fail "notarization submission failed"
+[ -n "$submission_id" ] || fail "notarization response did not contain a submission ID"
+[ "$notary_status" = Accepted ] || fail "notarization status is $notary_status"
+
+candidate_archive=$temporary/$output_name
+COPYFILE_DISABLE=1 tar -czf "$candidate_archive" -C "$temporary/extracted" "$package"
+
+mkdir "$temporary/final-check"
+COPYFILE_DISABLE=1 tar -xzf "$candidate_archive" -C "$temporary/final-check"
+final_binary=$temporary/final-check/$package/exfat-resize
+codesign --verify --strict --verbose=2 "$final_binary"
+if [ "$("$final_binary" --version)" != "exfat-resize $build_version" ]; then
+	fail "final archived CLI version is incorrect"
+fi
+notarization_attempt=1
+while ! notarization_check=$(codesign -vvvv -R=notarized \
+	--check-notarization "$final_binary" 2>&1); do
+	if [ "$notarization_attempt" -ge 6 ]; then
+		printf '%s\n' "$notarization_check" >&2
+		fail "notarization ticket is unavailable for the final CLI"
+	fi
+	notarization_attempt=$((notarization_attempt + 1))
+	sleep 5
+done
+printf '%s\n' "$notarization_check"
+
+install -m 0644 "$candidate_archive" "$output_archive"
+install -m 0644 "$notary_log" "$output_log"
+output_sha256=$(shasum -a 256 "$output_archive" | awk '{ print $1 }')
+printf 'built signed and notarized archive: %s\n' "$output_archive"
+printf 'notarization log: %s\n' "$output_log"
+printf 'Developer ID authority: %s\n' "$authority"
+printf 'Team Identifier: %s\n' "$team_identifier"
+printf 'output archive SHA-256: %s\n' "$output_sha256"


### PR DESCRIPTION
## Summary

- Build and test an ARM64-only macOS binary archive targeting macOS 11 or newer.
- Run the macOS binary workflow in regular CI alongside the Linux and Windows package workflows.
- Add a manual Developer ID signing and notarization helper that outputs only the signed executable.
- Use a protected `macos-release` environment to resume the release workflow after manual signing.
- Reconstruct the final archive in CI from the tested unsigned artifact, verifying that the signed executable matches the original code.
- Validate architecture, deployment target, dependencies, signature, hardened runtime, notarization, installation, uninstallation, and an actual exFAT resize.
- Document macOS installation, SHA-256 verification, signing, approval, and retry procedures.

The release remains a draft until it has been reviewed and published manually. No signing credentials are stored in GitHub.

## Testing

- CI passes, including the new macOS binary workflow.
- Full local test suite: 24/24 tests passed.
- End-to-end unsigned and ad-hoc-signed package simulation passed.
- Verified the published v1.0.5 Developer ID-signed executable against an exact rebuild.
- Confirmed that provenance verification rejects a different binary.
- Verified the final Developer ID archive, including online notarization, install/uninstall, and a real exFAT resize.