### PR TITLE
Move build and test guidance to CONTRIBUTING.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ install(
 foreach(exfat_resize_document_component IN ITEMS Runtime Development)
     install(
         FILES
+            CONTRIBUTING.md
             LICENSE
             README.md
         DESTINATION

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,60 @@
 # Contributing
 
-Build and test instructions are in the
-[README](README.md#build-and-test). Run the relevant tests before submitting a
-change.
+Run the relevant tests before submitting a change. The commands below cover the
+development build, test suites, sanitizer checks, and release verification. For
+the shorter user-oriented build and installation path, see the
+[README](README.md#build-from-source).
+
+## Build and test
+
+CMake 3.20 or newer is the canonical build system for the library, CLI, and
+tests. Package tests require Git.
+
+### macOS and Linux
+
+The top-level Makefile is a convenience wrapper around CMake and the release
+scripts. If the macOS CMake application is installed without command-line
+links, add its tools to `PATH`:
+
+    export PATH=/Applications/CMake.app/Contents/bin:$PATH
+
+Build the project and run its standard test suite with:
+
+    make
+    make test
+
+`make` produces `build/exfat-resize`. `make test` builds every target and runs
+the separately labeled library, package, and CLI suites through CTest. The CLI
+tests use newfs_exfat and fsck_exfat on macOS, or mkfs.exfat and fsck.exfat on
+Linux.
+
+For broader validation, run:
+
+    make sanitize-test
+
+The sanitizer target runs all suites with AddressSanitizer and
+UndefinedBehaviorSanitizer in a separate build directory. It also builds and
+runs C and C++ `add_subdirectory()` consumers to verify the sanitized static
+library's runtime link requirements.
+
+When changing build, installation, packaging, or release behavior, or when
+preparing a release, also run:
+
+    make release-test
+
+The release target creates and verifies the source archive from committed
+`HEAD`, installs it into a temporary prefix, and builds C and C++ consumers
+using both `find_package()` and `add_subdirectory()`. It requires `ssh-keygen` in
+addition to the standard build and test prerequisites.
+
+### Windows
+
+The Windows build includes the CLI and library by default. It uses only native
+Windows APIs and does not require a POSIX compatibility layer:
+
+    cmake -S . -B build
+    cmake --build build --config Release
+    ctest --test-dir build --build-config Release --output-on-failure -L "library|cli|package-native"
 
 ## C identifier namespaces
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ and platform-specific setup.
 ### Build from source
 
 The checkout path below requires Git, CMake 3.20 or newer, and a C11 compiler.
-See [Build and test](#build-and-test) for platform-specific test prerequisites
-and the `PATH` setup needed when macOS CMake.app has no command-line links.
 
     git clone https://github.com/huven/exfat-resize.git
     cd exfat-resize
@@ -57,6 +55,15 @@ Windows. On other platforms, only the portable library is built by default.
 
 The install command may require elevated privileges depending on the destination
 prefix.
+
+For a custom installation prefix:
+
+    cmake --install build --config Release --prefix /your/prefix
+
+On macOS, if CMake.app is installed without command-line links, add its tools to
+`PATH`:
+
+    export PATH=/Applications/CMake.app/Contents/bin:$PATH
 
 Before using the tool, read [Safety](#safety), then see [Usage](#usage)
 for supported targets and examples.
@@ -450,54 +457,13 @@ CLI from the extracted directory:
     cd exfat-resize-X.Y.Z-windows-x86_64
     .\exfat-resize.exe --version
 
-The archive also contains the license, this README, and the resize-transaction
-documentation. Resizing an image file normally does not require elevation. To
-access a logical volume or grow its partition, open PowerShell or Command Prompt
-as Administrator and invoke the extracted executable as described under
-[Windows usage](#windows).
+The archive also contains the license, this README, the contribution guide, and
+the resize-transaction documentation. Resizing an image file normally does not
+require elevation. To access a logical volume or grow its partition, open
+PowerShell or Command Prompt as Administrator and invoke the extracted
+executable as described under [Windows usage](#windows).
 
-## Build and test
+## Contributing
 
-CMake 3.20 or newer is the canonical build system for the library, CLI, and
-tests. Package tests require Git.
-
-### macOS and Linux
-
-The top-level Makefile is a convenience wrapper around CMake and the release
-scripts. If the macOS CMake application is installed without command-line
-links, add its tools to `PATH`:
-
-    export PATH=/Applications/CMake.app/Contents/bin:$PATH
-
-    make
-    make test
-    make sanitize-test
-    make release-test
-
-The complete macOS and Linux test suite also requires `ssh-keygen` for its
-release checks.
-
-`make` produces `build/exfat-resize`. `make test` builds every target and runs
-the separately labeled library, package, and CLI suites through CTest. The CLI
-tests use newfs_exfat and fsck_exfat on macOS, or mkfs.exfat and fsck.exfat on
-Linux. The sanitizer target runs all suites with AddressSanitizer and
-UndefinedBehaviorSanitizer in a separate build directory. It also builds and
-runs C and C++ `add_subdirectory()` consumers to verify the sanitized static
-library's runtime link requirements.
-The release target creates and verifies the source archive from committed
-`HEAD`, installs it into a temporary prefix, and builds C and C++ consumers
-using both `find_package()` and `add_subdirectory()`.
-
-For a custom installation prefix:
-
-    cmake --install build --prefix /your/prefix
-
-### Windows build
-
-The Windows build includes the CLI and library by default. It uses only native
-Windows APIs and does not require a POSIX compatibility layer:
-
-    cmake -S . -B build
-    cmake --build build --config Release
-    ctest --test-dir build --build-config Release --output-on-failure -L "library|cli|package-native"
-    cmake --install build --config Release
+See [Contributing](CONTRIBUTING.md) for the development setup, test suites,
+sanitizer and release checks, and source conventions.

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -27,6 +27,8 @@ mkdir -p "$install_root/bin" "$install_root/share/man/man8" "$install_root/share
 mkdir -p "$install_root/share/doc/exfat-resize/docs"
 install -m 0755 "$archive_directory/exfat-resize" "$install_root/bin/exfat-resize"
 install -m 0644 "$archive_directory/exfat-resize.8" "$install_root/share/man/man8/exfat-resize.8"
+install -m 0644 "$archive_directory/CONTRIBUTING.md" \
+	"$install_root/share/doc/exfat-resize/CONTRIBUTING.md"
 install -m 0644 "$archive_directory/LICENSE" "$install_root/share/doc/exfat-resize/LICENSE"
 install -m 0644 "$archive_directory/README.md" "$install_root/share/doc/exfat-resize/README.md"
 install -m 0644 "$archive_directory/docs/TRANSACTION.md" \

--- a/packaging/linux/uninstall.sh
+++ b/packaging/linux/uninstall.sh
@@ -23,6 +23,7 @@ esac
 
 install_root=$destdir$prefix
 rm -f "$install_root/bin/exfat-resize" "$install_root/share/man/man8/exfat-resize.8" \
+	"$install_root/share/doc/exfat-resize/CONTRIBUTING.md" \
 	"$install_root/share/doc/exfat-resize/LICENSE" \
 	"$install_root/share/doc/exfat-resize/README.md" \
 	"$install_root/share/doc/exfat-resize/docs/TRANSACTION.md"

--- a/tests/package/install_test.cmake.in
+++ b/tests/package/install_test.cmake.in
@@ -18,6 +18,7 @@ set(installed_version_config
     "${install_prefix}/@CMAKE_INSTALL_LIBDIR@/cmake/exfat_resize/exfat_resizeConfigVersion.cmake"
 )
 set(documentation_dir "${install_prefix}/@CMAKE_INSTALL_DOCDIR@")
+set(contributing "${documentation_dir}/CONTRIBUTING.md")
 set(readme "${documentation_dir}/README.md")
 set(license "${documentation_dir}/LICENSE")
 set(transaction_document "${documentation_dir}/docs/TRANSACTION.md")
@@ -59,6 +60,7 @@ foreach(required_file
         "${installed_header}"
         "${installed_config}"
         "${installed_version_config}"
+        "${contributing}"
         "${readme}"
         "${license}"
         "${transaction_document}"
@@ -98,6 +100,7 @@ foreach(required_file
         "${development_package_dir}/exfat_resizeTargets.cmake"
         "${development_package_dir}/exfat_resizeConfig.cmake"
         "${development_package_dir}/exfat_resizeConfigVersion.cmake"
+        "${development_documentation_dir}/CONTRIBUTING.md"
         "${development_documentation_dir}/README.md"
         "${development_documentation_dir}/LICENSE"
         "${development_documentation_dir}/docs/TRANSACTION.md"

--- a/tests/package/linux-binary-test.sh
+++ b/tests/package/linux-binary-test.sh
@@ -46,7 +46,8 @@ if [ "$top_level" != "$package" ] || [ ! -d "$package_directory" ]; then
 	exit 1
 fi
 expected=$(
-	printf '%s\n' LICENSE README.md docs exfat-resize exfat-resize.8 install.sh uninstall.sh |
+	printf '%s\n' CONTRIBUTING.md LICENSE README.md docs exfat-resize exfat-resize.8 \
+		install.sh uninstall.sh |
 		sort
 )
 actual=$(find "$package_directory" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)
@@ -67,6 +68,7 @@ if [ "$(stat -c '%a' "$package_directory/exfat-resize")" != 755 ] ||
 	exit 1
 fi
 if [ "$(stat -c '%a' "$package_directory/exfat-resize.8")" != 644 ] ||
+	[ "$(stat -c '%a' "$package_directory/CONTRIBUTING.md")" != 644 ] ||
 	[ "$(stat -c '%a' "$package_directory/LICENSE")" != 644 ] ||
 	[ "$(stat -c '%a' "$package_directory/README.md")" != 644 ] ||
 	[ "$(stat -c '%a' "$package_directory/docs/TRANSACTION.md")" != 644 ]; then
@@ -81,6 +83,7 @@ if ! grep -F "exfat-resize $build_version" "$package_directory/exfat-resize.8" >
 	echo "archived manual page has an incorrect version" >&2
 	exit 1
 fi
+cmp "$source_directory/CONTRIBUTING.md" "$package_directory/CONTRIBUTING.md"
 cmp "$source_directory/LICENSE" "$package_directory/LICENSE"
 cmp "$source_directory/README.md" "$package_directory/README.md"
 cmp "$source_directory/docs/TRANSACTION.md" "$package_directory/docs/TRANSACTION.md"
@@ -89,16 +92,18 @@ DESTDIR=$temporary/install-root "$package_directory/install.sh"
 install_prefix=$temporary/install-root/usr/local
 installed_binary=$install_prefix/bin/exfat-resize
 installed_manual=$install_prefix/share/man/man8/exfat-resize.8
+installed_contributing=$install_prefix/share/doc/exfat-resize/CONTRIBUTING.md
 installed_license=$install_prefix/share/doc/exfat-resize/LICENSE
 installed_readme=$install_prefix/share/doc/exfat-resize/README.md
 installed_transaction=$install_prefix/share/doc/exfat-resize/docs/TRANSACTION.md
 if [ "$("$installed_binary" --version)" != "exfat-resize $build_version" ] ||
 	[ ! -f "$installed_manual" ] || [ ! -f "$installed_license" ] ||
-	[ ! -f "$installed_readme" ] || [ ! -f "$installed_transaction" ]; then
+	[ ! -f "$installed_contributing" ] || [ ! -f "$installed_readme" ] ||
+	[ ! -f "$installed_transaction" ]; then
 	echo "installed Linux archive is incomplete" >&2
 	exit 1
 fi
-if [ "$(find "$install_prefix" -type f | wc -l)" -ne 5 ]; then
+if [ "$(find "$install_prefix" -type f | wc -l)" -ne 6 ]; then
 	echo "installer created an unexpected file set" >&2
 	exit 1
 fi
@@ -108,7 +113,8 @@ touch "$install_prefix/bin/unrelated" "$install_prefix/share/man/man8/unrelated.
 	"$install_prefix/share/doc/exfat-resize/docs/unrelated"
 DESTDIR=$temporary/install-root "$package_directory/uninstall.sh"
 if [ -e "$installed_binary" ] || [ -e "$installed_manual" ] || [ -e "$installed_license" ] ||
-	[ -e "$installed_readme" ] || [ -e "$installed_transaction" ]; then
+	[ -e "$installed_contributing" ] || [ -e "$installed_readme" ] ||
+	[ -e "$installed_transaction" ]; then
 	echo "uninstaller left an installed project file behind" >&2
 	exit 1
 fi

--- a/tests/package/macos-binary-test.sh
+++ b/tests/package/macos-binary-test.sh
@@ -71,6 +71,7 @@ fi
 expected_entries=$(
 	printf '%s\n' \
 		"$package/" \
+		"$package/CONTRIBUTING.md" \
 		"$package/LICENSE" \
 		"$package/README.md" \
 		"$package/docs/" \
@@ -102,7 +103,8 @@ if [ "$top_level" != "$package" ] || [ ! -d "$package_directory" ]; then
 	exit 1
 fi
 expected=$(
-	printf '%s\n' LICENSE README.md docs exfat-resize exfat-resize.8 install.sh uninstall.sh |
+	printf '%s\n' CONTRIBUTING.md LICENSE README.md docs exfat-resize exfat-resize.8 \
+		install.sh uninstall.sh |
 		sort
 )
 actual=$(find "$package_directory" -mindepth 1 -maxdepth 1 -exec basename {} \; | sort)
@@ -123,6 +125,7 @@ if [ "$(stat -f '%Lp' "$package_directory/exfat-resize")" != 755 ] ||
 	exit 1
 fi
 if [ "$(stat -f '%Lp' "$package_directory/exfat-resize.8")" != 644 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/CONTRIBUTING.md")" != 644 ] ||
 	[ "$(stat -f '%Lp' "$package_directory/LICENSE")" != 644 ] ||
 	[ "$(stat -f '%Lp' "$package_directory/README.md")" != 644 ] ||
 	[ "$(stat -f '%Lp' "$package_directory/docs/TRANSACTION.md")" != 644 ]; then
@@ -139,6 +142,7 @@ if ! grep -F "exfat-resize $build_version" "$package_directory/exfat-resize.8" >
 	echo "archived manual page has an incorrect version" >&2
 	exit 1
 fi
+cmp "$source_directory/CONTRIBUTING.md" "$package_directory/CONTRIBUTING.md"
 cmp "$source_directory/LICENSE" "$package_directory/LICENSE"
 cmp "$source_directory/README.md" "$package_directory/README.md"
 cmp "$source_directory/docs/TRANSACTION.md" "$package_directory/docs/TRANSACTION.md"
@@ -207,16 +211,18 @@ DESTDIR=$temporary/install-root "$package_directory/install.sh"
 install_prefix=$temporary/install-root/usr/local
 installed_binary=$install_prefix/bin/exfat-resize
 installed_manual=$install_prefix/share/man/man8/exfat-resize.8
+installed_contributing=$install_prefix/share/doc/exfat-resize/CONTRIBUTING.md
 installed_license=$install_prefix/share/doc/exfat-resize/LICENSE
 installed_readme=$install_prefix/share/doc/exfat-resize/README.md
 installed_transaction=$install_prefix/share/doc/exfat-resize/docs/TRANSACTION.md
 if [ "$("$installed_binary" --version)" != "exfat-resize $build_version" ] ||
 	[ ! -f "$installed_manual" ] || [ ! -f "$installed_license" ] ||
-	[ ! -f "$installed_readme" ] || [ ! -f "$installed_transaction" ]; then
+	[ ! -f "$installed_contributing" ] || [ ! -f "$installed_readme" ] ||
+	[ ! -f "$installed_transaction" ]; then
 	echo "installed macOS archive is incomplete" >&2
 	exit 1
 fi
-if [ "$(find "$install_prefix" -type f | wc -l)" -ne 5 ]; then
+if [ "$(find "$install_prefix" -type f | wc -l)" -ne 6 ]; then
 	echo "installer created an unexpected file set" >&2
 	exit 1
 fi
@@ -233,7 +239,8 @@ touch "$install_prefix/bin/unrelated" "$install_prefix/share/man/man8/unrelated.
 	"$install_prefix/share/doc/exfat-resize/docs/unrelated"
 DESTDIR=$temporary/install-root "$package_directory/uninstall.sh"
 if [ -e "$installed_binary" ] || [ -e "$installed_manual" ] || [ -e "$installed_license" ] ||
-	[ -e "$installed_readme" ] || [ -e "$installed_transaction" ]; then
+	[ -e "$installed_contributing" ] || [ -e "$installed_readme" ] ||
+	[ -e "$installed_transaction" ]; then
 	echo "uninstaller left an installed project file behind" >&2
 	exit 1
 fi

--- a/tests/package/release-package.sh
+++ b/tests/package/release-package.sh
@@ -122,6 +122,8 @@ fi
 "$cmake_command" --build "$temporary/package-build" --parallel
 "$cmake_command" --install "$temporary/package-build"
 
+cmp "$source_tree/CONTRIBUTING.md" \
+	"$temporary/prefix/share/doc/exfat_resize/CONTRIBUTING.md"
 cmp "$source_tree/LICENSE" "$temporary/prefix/share/doc/exfat_resize/LICENSE"
 cmp "$source_tree/README.md" "$temporary/prefix/share/doc/exfat_resize/README.md"
 installed_cli_version=$("$temporary/prefix/bin/exfat-resize" --version)

--- a/tests/package/windows-binary-test.ps1
+++ b/tests/package/windows-binary-test.ps1
@@ -86,6 +86,7 @@ try {
         $_.FullName.Substring($PackageDirectory.Length + 1).Replace('\', '/')
     } | Sort-Object)
     $Expected = @(
+        "CONTRIBUTING.md",
         "docs",
         "docs/TRANSACTION.md",
         "exfat-resize.exe",
@@ -102,6 +103,8 @@ try {
     & $Binary --help | Out-Null
     Assert-Condition ($LASTEXITCODE -eq 0) "Archived CLI help command failed"
 
+    Assert-SameFile (Join-Path $SourceDirectory "CONTRIBUTING.md") `
+        (Join-Path $PackageDirectory "CONTRIBUTING.md")
     Assert-SameFile (Join-Path $SourceDirectory "LICENSE") `
         (Join-Path $PackageDirectory "LICENSE")
     Assert-SameFile (Join-Path $SourceDirectory "README.md") `

--- a/tools/build-linux-binary.sh
+++ b/tools/build-linux-binary.sh
@@ -70,11 +70,12 @@ mkdir -p "$temporary/build" "$temporary/stage" "$output_directory"
 binary=$temporary/stage/usr/local/bin/exfat-resize
 manual=$temporary/stage/usr/local/share/man/man8/exfat-resize.8
 documentation=$temporary/stage/usr/local/share/doc/exfat_resize
+contributing=$documentation/CONTRIBUTING.md
 license=$documentation/LICENSE
 readme=$documentation/README.md
 transaction=$documentation/docs/TRANSACTION.md
 if [ ! -x "$binary" ] || [ ! -f "$manual" ] || [ ! -f "$license" ] ||
-	[ ! -f "$readme" ] || [ ! -f "$transaction" ]; then
+	[ ! -f "$contributing" ] || [ ! -f "$readme" ] || [ ! -f "$transaction" ]; then
 	echo "CMake runtime installation is incomplete" >&2
 	exit 1
 fi
@@ -111,6 +112,7 @@ package_directory=$temporary/$package
 mkdir -p "$package_directory/docs"
 install -m 0755 "$binary" "$package_directory/exfat-resize"
 install -m 0644 "$manual" "$package_directory/exfat-resize.8"
+install -m 0644 "$contributing" "$package_directory/CONTRIBUTING.md"
 install -m 0644 "$license" "$package_directory/LICENSE"
 install -m 0644 "$readme" "$package_directory/README.md"
 install -m 0644 "$transaction" "$package_directory/docs/TRANSACTION.md"

--- a/tools/build-macos-binary.sh
+++ b/tools/build-macos-binary.sh
@@ -75,11 +75,12 @@ mkdir -p "$temporary/build" "$temporary/stage" "$output_directory"
 binary=$temporary/stage/usr/local/bin/exfat-resize
 manual=$temporary/stage/usr/local/share/man/man8/exfat-resize.8
 documentation=$temporary/stage/usr/local/share/doc/exfat_resize
+contributing=$documentation/CONTRIBUTING.md
 license=$documentation/LICENSE
 readme=$documentation/README.md
 transaction=$documentation/docs/TRANSACTION.md
 if [ ! -x "$binary" ] || [ ! -f "$manual" ] || [ ! -f "$license" ] ||
-	[ ! -f "$readme" ] || [ ! -f "$transaction" ]; then
+	[ ! -f "$contributing" ] || [ ! -f "$readme" ] || [ ! -f "$transaction" ]; then
 	echo "CMake runtime installation is incomplete" >&2
 	exit 1
 fi
@@ -122,6 +123,7 @@ package_directory=$temporary/$package
 mkdir -p "$package_directory/docs"
 install -m 0755 "$binary" "$package_directory/exfat-resize"
 install -m 0644 "$manual" "$package_directory/exfat-resize.8"
+install -m 0644 "$contributing" "$package_directory/CONTRIBUTING.md"
 install -m 0644 "$license" "$package_directory/LICENSE"
 install -m 0644 "$readme" "$package_directory/README.md"
 install -m 0644 "$transaction" "$package_directory/docs/TRANSACTION.md"

--- a/tools/build-windows-binary.ps1
+++ b/tools/build-windows-binary.ps1
@@ -88,10 +88,11 @@ try {
 
     $Binary = Join-Path $StageDirectory "bin/exfat-resize.exe"
     $Documentation = Join-Path $StageDirectory "share/doc/exfat_resize"
+    $Contributing = Join-Path $Documentation "CONTRIBUTING.md"
     $License = Join-Path $Documentation "LICENSE"
     $Readme = Join-Path $Documentation "README.md"
     $Transaction = Join-Path $Documentation "docs/TRANSACTION.md"
-    foreach ($RequiredFile in @($Binary, $License, $Readme, $Transaction)) {
+    foreach ($RequiredFile in @($Binary, $Contributing, $License, $Readme, $Transaction)) {
         if (-not (Test-Path -LiteralPath $RequiredFile -PathType Leaf)) {
             throw "CMake runtime installation is incomplete: $RequiredFile"
         }
@@ -105,6 +106,7 @@ try {
     $PackageDocumentation = Join-Path $PackageDirectory "docs"
     New-Item -ItemType Directory -Path $PackageDocumentation | Out-Null
     Copy-Item -LiteralPath $Binary -Destination $PackageDirectory
+    Copy-Item -LiteralPath $Contributing -Destination $PackageDirectory
     Copy-Item -LiteralPath $License -Destination $PackageDirectory
     Copy-Item -LiteralPath $Readme -Destination $PackageDirectory
     Copy-Item -LiteralPath $Transaction -Destination $PackageDocumentation


### PR DESCRIPTION
Keep the README focused on installation and user-facing source builds. Ship CONTRIBUTING.md with installed documentation and binary archives so relative documentation links remain valid.