### PR TITLE
Test multi-cluster contiguous child directories

### DIFF
--- a/tests/library/integration/resize_tests.c
+++ b/tests/library/integration/resize_tests.c
@@ -92,6 +92,26 @@ static enum exfat_resize_error plan_fixture_growth(struct exfat_fixture *fixture
 	    &device_geometry, &fixture->geometry, target_sector_count, target);
 }
 
+static uint32_t expected_displaced_cluster_count(
+    const struct exfat_resize_geometry *source, const struct exfat_resize_geometry *target)
+{
+	uint64_t heap_movement = (uint64_t)target->cluster_heap_offset - source->cluster_heap_offset;
+	uint64_t displaced = heap_movement / source->sectors_per_cluster;
+
+	return displaced > source->cluster_count ? source->cluster_count : (uint32_t)displaced;
+}
+
+static uint32_t expected_mapped_cluster(const struct exfat_resize_geometry *source,
+    const struct exfat_resize_geometry *target,
+    uint32_t source_cluster)
+{
+	uint32_t displaced = expected_displaced_cluster_count(source, target);
+	uint32_t remaining = source->cluster_count - displaced;
+	uint32_t source_index = source_cluster - 2;
+
+	return source_index < displaced ? remaining + 2 + source_index : 2 + source_index - displaced;
+}
+
 static void *tracked_allocate(void *context, size_t size)
 {
 	struct allocator_state *state = context;
@@ -2082,6 +2102,137 @@ static void test_deep_directory_tree(void)
 	exfat_fixture_destroy(&fixture);
 }
 
+static void run_multi_cluster_no_fat_chain_child_directory(
+    uint64_t target_sector_count, int crosses_mapping_boundary)
+{
+	enum { DIRECTORY_CLUSTER_COUNT = 3, DATA_FIRST_CLUSTER = 2000 };
+	struct exfat_resize_geometry target;
+	struct exfat_resize_options options = resize_options();
+	struct exfat_fixture fixture;
+	unsigned char source_directories[DIRECTORY_CLUSTER_COUNT][SECTOR_SIZE];
+	unsigned char target_directory[SECTOR_SIZE];
+	unsigned char root[SECTOR_SIZE];
+	enum exfat_resize_error error;
+	uint64_t directory_data_length = DIRECTORY_CLUSTER_COUNT * (uint64_t)SECTOR_SIZE;
+	uint32_t bitmap_cluster = 0;
+	uint32_t boundary;
+	uint32_t directory_first_cluster;
+	uint32_t index;
+	uint32_t parent_first_cluster = 0;
+	uint64_t parent_data_length = 0;
+	uint16_t stored_checksum = 0;
+
+	CHECK(exfat_fixture_initialize(&fixture, target_sector_count) == 0);
+	error = plan_fixture_growth(&fixture, target_sector_count, &target);
+	CHECK(error == EXFAT_RESIZE_SUCCESS);
+	if (error != EXFAT_RESIZE_SUCCESS) {
+		exfat_fixture_destroy(&fixture);
+		return;
+	}
+	boundary = expected_displaced_cluster_count(&fixture.geometry, &target) + 2;
+	if (crosses_mapping_boundary)
+		CHECK(boundary > fixture.crossing_first_cluster + fixture.crossing_cluster_count);
+	CHECK(boundary + DIRECTORY_CLUSTER_COUNT <= fixture.geometry.cluster_count + 2);
+	directory_first_cluster = crosses_mapping_boundary ? boundary - 1 : 500;
+	if (crosses_mapping_boundary) {
+		CHECK(directory_first_cluster < boundary);
+		CHECK(directory_first_cluster + DIRECTORY_CLUSTER_COUNT > boundary);
+	} else {
+		CHECK(directory_first_cluster >= boundary ||
+		    directory_first_cluster + DIRECTORY_CLUSTER_COUNT <= boundary);
+	}
+	CHECK(exfat_fixture_add_contiguous_child_directory(
+	          &fixture, directory_first_cluster, DIRECTORY_CLUSTER_COUNT, DATA_FIRST_CLUSTER) == 0);
+	for (index = 0; index < DIRECTORY_CLUSTER_COUNT; ++index) {
+		CHECK(exfat_fixture_read_sector(&fixture,
+		          exfat_fixture_cluster_sector(&fixture.geometry, directory_first_cluster + index),
+		          source_directories[index], sizeof(source_directories[index])) == 0);
+	}
+	memory_block_device_clear_operations(&fixture.memory);
+
+	error = exfat_fixture_resize(&fixture.memory.device, target_sector_count, &options, NULL);
+	CHECK(error == EXFAT_RESIZE_SUCCESS);
+	if (error != EXFAT_RESIZE_SUCCESS) {
+		exfat_fixture_destroy(&fixture);
+		return;
+	}
+	for (index = 0; index < DIRECTORY_CLUSTER_COUNT; ++index) {
+		uint32_t target_cluster =
+		    expected_mapped_cluster(&fixture.geometry, &target, directory_first_cluster + index);
+		uint64_t target_sector = exfat_fixture_cluster_sector(&target, target_cluster);
+
+		CHECK(sector_operation_count(&fixture, MEMORY_OPERATION_READ, target_sector) != 0);
+		CHECK(sector_operation_count(&fixture, MEMORY_OPERATION_WRITE, target_sector) != 0);
+	}
+
+	CHECK(exfat_fixture_read_sector(&fixture,
+	          exfat_fixture_cluster_sector(&target,
+	              expected_mapped_cluster(
+	                  &fixture.geometry, &target, fixture.geometry.root_directory_cluster)),
+	          root, sizeof(root)) == 0);
+	CHECK(root[5 * 32] == ENTRY_FILE);
+	CHECK(root[6 * 32] == ENTRY_STREAM);
+	CHECK(((root[6 * 32 + 1] & NO_FAT_CHAIN) != 0) == !crosses_mapping_boundary);
+	CHECK(exfat_resize_load_le16(root + 5 * 32, sizeof(root) - 5 * 32, 2, &stored_checksum) ==
+	    EXFAT_RESIZE_SUCCESS);
+	CHECK(stored_checksum == entry_set_checksum(root + 5 * 32));
+	CHECK(exfat_resize_load_le32(root + 6 * 32, sizeof(root) - 6 * 32, 20, &parent_first_cluster) ==
+	    EXFAT_RESIZE_SUCCESS);
+	CHECK(parent_first_cluster ==
+	    expected_mapped_cluster(&fixture.geometry, &target, directory_first_cluster));
+	CHECK(exfat_resize_load_le64(root + 6 * 32, sizeof(root) - 6 * 32, 24, &parent_data_length) ==
+	    EXFAT_RESIZE_SUCCESS);
+	CHECK(parent_data_length == directory_data_length);
+	CHECK(exfat_resize_load_le32(root, sizeof(root), 20, &bitmap_cluster) == EXFAT_RESIZE_SUCCESS);
+
+	for (index = 0; index < DIRECTORY_CLUSTER_COUNT; ++index) {
+		uint32_t source_data_cluster = DATA_FIRST_CLUSTER + index;
+		uint32_t target_data_cluster =
+		    expected_mapped_cluster(&fixture.geometry, &target, source_data_cluster);
+		uint32_t target_directory_cluster =
+		    expected_mapped_cluster(&fixture.geometry, &target, directory_first_cluster + index);
+		uint32_t expected_next = 0;
+		uint32_t stored_data_cluster = 0;
+
+		CHECK(exfat_fixture_read_sector(&fixture,
+		          exfat_fixture_cluster_sector(&target, target_directory_cluster), target_directory,
+		          sizeof(target_directory)) == 0);
+		check_file_primary_entries_preserved(source_directories[index], target_directory);
+		CHECK(target_directory[0] == ENTRY_FILE);
+		CHECK(target_directory[32] == ENTRY_STREAM);
+		CHECK((target_directory[32 + 1] & NO_FAT_CHAIN) != 0);
+		CHECK(exfat_resize_load_le16(target_directory, sizeof(target_directory), 2,
+		          &stored_checksum) == EXFAT_RESIZE_SUCCESS);
+		CHECK(stored_checksum == entry_set_checksum(target_directory));
+		CHECK(exfat_resize_load_le32(target_directory + 32, sizeof(target_directory) - 32, 20,
+		          &stored_data_cluster) == EXFAT_RESIZE_SUCCESS);
+		CHECK(stored_data_cluster == target_data_cluster);
+		check_cluster_pattern(&fixture, &target, source_data_cluster, target_data_cluster);
+		CHECK(bitmap_cluster_is_set(&fixture, &target, bitmap_cluster, target_directory_cluster));
+		CHECK(bitmap_cluster_is_set(&fixture, &target, bitmap_cluster, target_data_cluster));
+		CHECK(load_fat_entry(&fixture, &target, target_data_cluster) == 0);
+
+		if (crosses_mapping_boundary) {
+			expected_next = index + 1 == DIRECTORY_CLUSTER_COUNT
+			    ? UINT32_C(0xffffffff)
+			    : expected_mapped_cluster(
+			          &fixture.geometry, &target, directory_first_cluster + index + 1);
+		}
+		CHECK(load_fat_entry(&fixture, &target, target_directory_cluster) == expected_next);
+	}
+	exfat_fixture_destroy(&fixture);
+}
+
+static void test_multi_cluster_no_fat_chain_child_directory(void)
+{
+	run_multi_cluster_no_fat_chain_child_directory(TARGET_SECTOR_COUNT, 0);
+}
+
+static void test_crossing_multi_cluster_no_fat_chain_child_directory(void)
+{
+	run_multi_cluster_no_fat_chain_child_directory(UINT32_C(131072), 1);
+}
+
 static void test_identity_mapping_rewrites_only_bitmap(void)
 {
 	static const struct {
@@ -2714,6 +2865,8 @@ int main(void)
 	test_directory_worklist_growth();
 	test_directory_worklist_allocation_failure();
 	test_deep_directory_tree();
+	test_multi_cluster_no_fat_chain_child_directory();
+	test_crossing_multi_cluster_no_fat_chain_child_directory();
 	test_identity_mapping_rewrites_only_bitmap();
 	test_no_fat_chain_ignores_stale_fat();
 	test_failure_leaves_volume_dirty();

--- a/tests/library/support/exfat_fixture.c
+++ b/tests/library/support/exfat_fixture.c
@@ -241,7 +241,8 @@ static void set_bitmap_cluster(unsigned char *bitmap, uint32_t cluster)
 	bitmap[bit / 8] |= (unsigned char)(1u << (bit % 8));
 }
 
-static int write_bitmap_cluster(struct exfat_fixture *fixture, uint32_t cluster)
+static int write_bitmap_cluster_state(
+    struct exfat_fixture *fixture, uint32_t cluster, int allocated)
 {
 	unsigned char sector[SECTOR_SIZE];
 	uint32_t bit;
@@ -262,8 +263,16 @@ static int write_bitmap_cluster(struct exfat_fixture *fixture, uint32_t cluster)
 	    sector_in_cluster;
 	if (fixture->memory.device.read(fixture->memory.device.context, sector_number, 1, sector) != 0)
 		return -1;
-	sector[bit / 8 % SECTOR_SIZE] |= (unsigned char)(1u << (bit % 8));
+	if (allocated)
+		sector[bit / 8 % SECTOR_SIZE] |= (unsigned char)(1u << (bit % 8));
+	else
+		sector[bit / 8 % SECTOR_SIZE] &= (unsigned char)~(1u << (bit % 8));
 	return write_sectors(fixture, sector_number, 1, sector);
+}
+
+static int write_bitmap_cluster(struct exfat_fixture *fixture, uint32_t cluster)
+{
+	return write_bitmap_cluster_state(fixture, cluster, 1);
 }
 
 static int initialize_bitmap(struct exfat_fixture *fixture)
@@ -524,6 +533,69 @@ static int write_cluster_pattern(struct exfat_fixture *fixture, uint32_t cluster
 		if (write_sectors(fixture,
 		        exfat_fixture_cluster_sector(&fixture->geometry, cluster) + sector_index, 1,
 		        sector) != 0)
+			return -1;
+	}
+	return 0;
+}
+
+int exfat_fixture_add_contiguous_child_directory(struct exfat_fixture *fixture,
+    uint32_t directory_first_cluster,
+    uint32_t directory_cluster_count,
+    uint32_t data_first_cluster)
+{
+	unsigned char entry_set[SECTOR_SIZE] = { 0 };
+	unsigned char root[SECTOR_SIZE];
+	uint64_t directory_data_length;
+	uint32_t index;
+	size_t offset = 0;
+
+	if (fixture->geometry.sectors_per_cluster != 1 || directory_cluster_count == 0 ||
+	    directory_cluster_count > 26 || directory_first_cluster < 2 || data_first_cluster < 2 ||
+	    (uint64_t)directory_first_cluster + directory_cluster_count >
+	        (uint64_t)fixture->geometry.cluster_count + 2 ||
+	    (uint64_t)data_first_cluster + directory_cluster_count >
+	        (uint64_t)fixture->geometry.cluster_count + 2 ||
+	    ((uint64_t)directory_first_cluster <
+	            (uint64_t)data_first_cluster + directory_cluster_count &&
+	        (uint64_t)data_first_cluster <
+	            (uint64_t)directory_first_cluster + directory_cluster_count))
+		return -1;
+	directory_data_length = (uint64_t)directory_cluster_count * SECTOR_SIZE;
+	if (exfat_fixture_read_sector(fixture,
+	        exfat_fixture_cluster_sector(
+	            &fixture->geometry, fixture->geometry.root_directory_cluster),
+	        root, sizeof(root)) != 0 ||
+	    append_file_set(entry_set, &offset, DIRECTORY_ATTRIBUTE, directory_first_cluster,
+	        directory_data_length, 1, 'D') != 0)
+		return -1;
+	memcpy(root + ENTRY_SIZE * 5, entry_set, ENTRY_SIZE * 3);
+	if (write_sectors(fixture,
+	        exfat_fixture_cluster_sector(
+	            &fixture->geometry, fixture->geometry.root_directory_cluster),
+	        1, root) != 0 ||
+	    write_bitmap_cluster_state(fixture, 6, 0) != 0 ||
+	    write_bitmap_cluster_state(fixture, 8, 0) != 0)
+		return -1;
+
+	for (index = 0; index < directory_cluster_count; ++index) {
+		unsigned char directory[SECTOR_SIZE] = { 0 };
+
+		offset = 0;
+		if (append_file_set(directory, &offset, ARCHIVE_ATTRIBUTE, data_first_cluster + index,
+		        SECTOR_SIZE, 1, (unsigned char)('a' + index)) != 0)
+			return -1;
+		if (index + 1 < directory_cluster_count) {
+			while (offset < sizeof(directory)) {
+				directory[offset] = 1;
+				offset += ENTRY_SIZE;
+			}
+		}
+		if (write_sectors(fixture,
+		        exfat_fixture_cluster_sector(&fixture->geometry, directory_first_cluster + index),
+		        1, directory) != 0 ||
+		    write_bitmap_cluster(fixture, directory_first_cluster + index) != 0 ||
+		    write_bitmap_cluster(fixture, data_first_cluster + index) != 0 ||
+		    write_cluster_pattern(fixture, data_first_cluster + index) != 0)
 			return -1;
 	}
 	return 0;

--- a/tests/library/support/exfat_fixture.h
+++ b/tests/library/support/exfat_fixture.h
@@ -45,6 +45,10 @@ int exfat_fixture_add_child_directories(
     struct exfat_fixture *fixture, uint32_t first_cluster, uint32_t count);
 int exfat_fixture_add_directory_chain(
     struct exfat_fixture *fixture, uint32_t first_cluster, uint32_t count);
+int exfat_fixture_add_contiguous_child_directory(struct exfat_fixture *fixture,
+    uint32_t directory_first_cluster,
+    uint32_t directory_cluster_count,
+    uint32_t data_first_cluster);
 
 int exfat_fixture_read_sector(
     struct exfat_fixture *fixture, uint64_t sector, void *buffer, size_t buffer_size);


### PR DESCRIPTION
Add a fixture helper for contiguous NoFatChain child directories spanning multiple clusters, with valid entry sets and payload allocations in every cluster.

Cover mappings that preserve contiguity and mappings that cross the relocation boundary and require conversion to a FAT chain. Verify rewritten references, checksums, payloads, FAT and bitmap state, and directory I/O.