### PR TITLE
Fix Windows partition growth target rounding

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -197,7 +197,9 @@ static int parse_size(const char *text, uint64_t *value)
 }
 
 static enum exfat_resize_error validate_partition_growth_preflight(
-    const struct exfat_resize_block_device *device, uint64_t target_size)
+    const struct exfat_resize_block_device *device,
+    uint64_t target_size,
+    uint64_t *effective_target_size)
 {
 	struct exfat_resize_device_geometry target_device_geometry;
 	struct exfat_resize_sector_adapter adapter;
@@ -222,6 +224,7 @@ static enum exfat_resize_error validate_partition_growth_preflight(
 		    &adapter.device, buffer, EXFAT_RESIZE_MAX_SECTOR_SIZE, &geometry);
 	if (result == EXFAT_RESIZE_SUCCESS) {
 		target_sector_count = target_size / filesystem_sector_size;
+		*effective_target_size = target_sector_count * (uint64_t)filesystem_sector_size;
 		if (target_sector_count <= geometry.volume_sector_count) {
 			result = EXFAT_RESIZE_INSUFFICIENT_GROWTH;
 		} else {
@@ -372,23 +375,23 @@ int cli_main(int argc, char **argv)
 			goto out;
 		}
 		current_size = device.block_device.sector_count * (uint64_t)device.block_device.sector_size;
-		if (target > current_size) {
-			/*
-			 * The library's complete preflight needs the requested target to fit the
-			 * device. Validate the source boot regions and target geometry before
-			 * changing that device's partition, then run the complete preflight.
-			 */
-			result = validate_partition_growth_preflight(&device.block_device, target);
-			if (result != EXFAT_RESIZE_SUCCESS) {
-				fprintf(stderr, "exfat-resize: cannot grow partition: preflight failed: %s\n",
-				    resize_error(result));
-				if (result == EXFAT_RESIZE_IO_ERROR && device.io_error_operation != NULL)
-					print_device_io_error(&device, positional[0]);
-				print_no_write_guidance();
-				goto out;
-			}
+		/*
+		 * The library's complete preflight cannot run until a requested target
+		 * beyond the current device fits. Validate the source and planned geometry
+		 * first, and use its filesystem-sector-rounded target for every subsequent
+		 * decision.
+		 */
+		result = validate_partition_growth_preflight(&device.block_device, target, &target);
+		if (result != EXFAT_RESIZE_SUCCESS) {
+			fprintf(stderr, "exfat-resize: cannot grow partition: preflight failed: %s\n",
+			    resize_error(result));
+			if (result == EXFAT_RESIZE_IO_ERROR && device.io_error_operation != NULL)
+				print_device_io_error(&device, positional[0]);
+			print_no_write_guidance();
+			goto out;
 		}
-		if (device_grow_partition(
+		if (target > current_size &&
+		    device_grow_partition(
 		        &device, positional[0], target, &partition_state, error, sizeof(error)) != 0) {
 			fprintf(stderr, "exfat-resize: %s\n", error);
 			if (partition_state == DEVICE_PARTITION_GROWN)

--- a/tests/cli/prepare-windows-volume.sh
+++ b/tests/cli/prepare-windows-volume.sh
@@ -33,14 +33,17 @@ done
 
 total_sectors=393216
 partition_start=2048
-initial_sectors=196608
-initial_end=$((partition_start + initial_sectors - 1))
-initial_bytes=$((initial_sectors * 512))
+filesystem_sectors=131072
+filesystem_end=$((partition_start + filesystem_sectors - 1))
+filesystem_bytes=$((filesystem_sectors * 512))
+partition_sectors=196608
+partition_end=$((partition_start + partition_sectors - 1))
+partition_bytes=$((partition_sectors * 512))
 
 mkdir -p "$mountpoint"
 truncate -s "$((total_sectors * 512))" "$raw"
 sgdisk --clear \
-	--new="1:${partition_start}:${initial_end}" \
+	--new="1:${partition_start}:${filesystem_end}" \
 	--typecode=1:0700 \
 	--change-name=1:EXRTEST "$raw" >/dev/null
 
@@ -82,10 +85,25 @@ sudo umount "$mountpoint"
 test_mount=
 sudo fsck.exfat -n "$partition"
 actual_bytes=$(sudo blockdev --getsize64 "$partition")
-if [ "$actual_bytes" -ne "$initial_bytes" ]; then
-	echo "wrong initial partition size: $actual_bytes, expected $initial_bytes" >&2
+if [ "$actual_bytes" -ne "$filesystem_bytes" ]; then
+	echo "wrong filesystem partition size: $actual_bytes, expected $filesystem_bytes" >&2
 	exit 1
 fi
+detach_raw_disk
+
+sgdisk --delete=1 "$raw" >/dev/null
+sgdisk \
+	--new="1:${partition_start}:${partition_end}" \
+	--typecode=1:0700 \
+	--change-name=1:EXRTEST "$raw" >/dev/null
+
+attach_raw_disk
+actual_bytes=$(sudo blockdev --getsize64 "$partition")
+if [ "$actual_bytes" -ne "$partition_bytes" ]; then
+	echo "wrong enlarged partition size: $actual_bytes, expected $partition_bytes" >&2
+	exit 1
+fi
+sudo fsck.exfat -n "$partition"
 sudo mount.exfat-fuse -o "uid=$(id -u),gid=$(id -g),ro" "$partition" "$mountpoint"
 test_mount=$mountpoint
 actual_hash=$(sha256sum "$mountpoint/payload.bin" | awk '{ print $1 }')

--- a/tests/cli/windows-volume.ps1
+++ b/tests/cli/windows-volume.ps1
@@ -53,7 +53,8 @@ function Invoke-CleanCheck {
 function Invoke-Resize {
     param(
         [string] $Target,
-        [uint64] $TargetSize
+        [uint64] $TargetSize,
+        [bool] $ExpectPartitionGrowth = $true
     )
 
     $Output = & $Program --grow-partition $Target $TargetSize 2>&1
@@ -62,8 +63,13 @@ function Invoke-Resize {
     Assert-Condition ($Status -eq 0) "exfat-resize failed for $Target (exit $Status)"
     Assert-Condition (($Output -join "`n") -match "exfat-resize: resized") `
         "exfat-resize did not report success for $Target"
-    Assert-Condition (($Output -join "`n") -match "grew the partition") `
-        "exfat-resize did not report partition growth for $Target"
+    if ($ExpectPartitionGrowth) {
+        Assert-Condition (($Output -join "`n") -match "grew the partition") `
+            "exfat-resize did not report partition growth for $Target"
+    } else {
+        Assert-Condition (($Output -join "`n") -notmatch "grew the partition") `
+            "exfat-resize unexpectedly reported partition growth for $Target"
+    }
 }
 
 function Invoke-ExpectedFailure {
@@ -193,8 +199,8 @@ function Test-VolumeTarget {
         # Get-Volume.Size is usable cluster capacity, not the exFAT VolumeLength.
         $InitialFileSystemSize = [uint64] $Volume.Size
         Assert-Condition (
-            $InitialFileSystemSize -ge 90MB -and $InitialFileSystemSize -le 100MB
-        ) "Initial usable filesystem capacity is $InitialFileSystemSize, expected about 94 MiB"
+            $InitialFileSystemSize -ge 58MB -and $InitialFileSystemSize -le 68MB
+        ) "Initial usable filesystem capacity is $InitialFileSystemSize, expected about 62 MiB"
         Assert-Condition (($Disk.Size - $Partition.Offset - $Partition.Size) -ge 60MB) `
             "Disk does not leave enough trailing space to test partition growth"
         Write-Host "Initial usable filesystem capacity: $InitialFileSystemSize bytes"
@@ -229,7 +235,7 @@ function Test-VolumeTarget {
         if ($TargetType -eq "DriveLetter") {
             Invoke-ExpectedFailure `
                 -Arguments @(
-                    "--grow-partition", $Target, [string] ([uint64] ($Partition.Size + 1))
+                    "--grow-partition", $Target, [string] ([uint64] (64MB + 1))
                 ) `
                 -ExpectedText "target does not add enough usable clusters"
             $Partition = Get-Partition -DiskNumber $Disk.Number `
@@ -246,6 +252,34 @@ function Test-VolumeTarget {
             Assert-Condition ($Partition.Size -eq 96MB) `
                 "Partition changed after an out-of-space failure"
         }
+
+        $OriginalPartitionSize = [uint64] $Partition.Size
+        if ($TargetType -eq "DriveLetter") {
+            $UnalignedIncrement = [uint64] 1
+        } else {
+            $UnalignedIncrement = [uint64] 511
+        }
+        $UnalignedTargetSize = $OriginalPartitionSize + $UnalignedIncrement
+        Invoke-Resize `
+            -Target $Target `
+            -TargetSize $UnalignedTargetSize `
+            -ExpectPartitionGrowth $false
+        Update-HostStorageCache
+        $Partition = Get-Partition -DiskNumber $Disk.Number `
+            -PartitionNumber $Partition.PartitionNumber
+        Assert-Condition ($Partition.Size -eq $OriginalPartitionSize) `
+            "Partition changed for a target that rounds down to its existing size"
+        $Volume = Wait-Volume $DriveLetter
+        Invoke-CleanCheck $DriveLetter
+        $Volume = Wait-Volume $DriveLetter
+        $IntermediateFileSystemSize = [uint64] $Volume.Size
+        Write-Host "Intermediate usable filesystem capacity: $IntermediateFileSystemSize bytes"
+        Assert-Condition ($IntermediateFileSystemSize -ge ($InitialFileSystemSize + 20MB)) `
+            "Filesystem did not grow into the existing partition"
+        Assert-Condition ($IntermediateFileSystemSize -le $Partition.Size) `
+            "Filesystem capacity exceeds the unchanged partition size"
+        Assert-Condition (($Partition.Size - $IntermediateFileSystemSize) -le 4MB) `
+            "Filesystem leaves more than 4 MiB of the unchanged partition unavailable"
 
         Invoke-Resize $Target $TargetSize
         Update-HostStorageCache


### PR DESCRIPTION
Normalize --grow-partition targets to the filesystem sector size during preflight and use the effective size throughout the resize operation.

Extend the existing Windows volume fixture and add regressions for +1 and +511 byte targets that must not enlarge the partition.