### PR TITLE
Accept independent exFAT boot region checksums

### DIFF
--- a/lib/boot_region.c
+++ b/lib/boot_region.c
@@ -48,7 +48,6 @@ struct exfat_boot_values {
 	uint8_t sectors_per_cluster_shift;
 	uint8_t number_of_fats;
 	uint8_t percent_in_use;
-	uint32_t checksum;
 };
 
 static enum exfat_resize_error load_boot_values(
@@ -273,7 +272,6 @@ static enum exfat_resize_error read_boot_region(const struct exfat_resize_block_
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
 
-	result.checksum = checksum;
 	error = validate_boot_values(device, &result, is_main);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
@@ -287,8 +285,7 @@ static int boot_regions_are_consistent(
 	const struct exfat_resize_geometry *left = &main->geometry;
 	const struct exfat_resize_geometry *right = &backup->geometry;
 
-	return main->checksum == backup->checksum &&
-	    left->volume_sector_count == right->volume_sector_count &&
+	return left->volume_sector_count == right->volume_sector_count &&
 	    left->sectors_per_cluster == right->sectors_per_cluster &&
 	    left->fat_offset == right->fat_offset && left->fat_length == right->fat_length &&
 	    left->cluster_heap_offset == right->cluster_heap_offset &&

--- a/tests/library/unit/boot_region_tests.c
+++ b/tests/library/unit/boot_region_tests.c
@@ -265,6 +265,30 @@ static void test_stale_backup_fields(void)
 	destroy_fixture(&fixture);
 }
 
+static void test_independent_region_checksums(void)
+{
+	struct exfat_resize_geometry geometry;
+	struct boot_fixture fixture;
+	enum exfat_resize_error error;
+
+	initialize_fixture(&fixture, 512);
+	if (fixture.image == NULL) {
+		destroy_fixture(&fixture);
+		return;
+	}
+
+	fixture_sector(&fixture, BACKUP_BOOT_REGION + 9)[0] = 1;
+	set_region_checksum(&fixture, BACKUP_BOOT_REGION);
+	write_fixture(&fixture);
+
+	error = read_fixture(&fixture, &geometry);
+	CHECK(error == EXFAT_RESIZE_SUCCESS);
+	if (error == EXFAT_RESIZE_SUCCESS)
+		check_geometry(&fixture, &geometry);
+
+	destroy_fixture(&fixture);
+}
+
 static void check_parse_failure(struct boot_fixture *fixture, enum exfat_resize_error expected)
 {
 	struct exfat_resize_geometry geometry;
@@ -596,6 +620,7 @@ int main(void)
 	test_valid_boot_regions(2048);
 	test_valid_boot_regions(4096);
 	test_stale_backup_fields();
+	test_independent_region_checksums();
 	test_checksums_and_region_consistency();
 	test_required_boot_structures();
 	test_unsupported_boot_values();


### PR DESCRIPTION
Continue validating each boot region and requiring matching resize geometry, but allow valid differences in checksum-covered contents.

Add a regression covering distinct backup OEM parameters with an independently valid checksum.