### PR TITLE
Simplify geometry arithmetic

### DIFF
--- a/lib/checked_math.c
+++ b/lib/checked_math.c
@@ -4,28 +4,6 @@
 
 #include "checked_math.h"
 
-enum exfat_resize_error exfat_resize_checked_add_u64(
-    uint64_t left, uint64_t right, uint64_t *result)
-{
-	if (result == NULL)
-		return EXFAT_RESIZE_INVALID_ARGUMENT;
-	if (right > UINT64_MAX - left)
-		return EXFAT_RESIZE_ARITHMETIC_OVERFLOW;
-	*result = left + right;
-	return EXFAT_RESIZE_SUCCESS;
-}
-
-enum exfat_resize_error exfat_resize_checked_multiply_u64(
-    uint64_t left, uint64_t right, uint64_t *result)
-{
-	if (result == NULL)
-		return EXFAT_RESIZE_INVALID_ARGUMENT;
-	if (left != 0 && right > UINT64_MAX / left)
-		return EXFAT_RESIZE_ARITHMETIC_OVERFLOW;
-	*result = left * right;
-	return EXFAT_RESIZE_SUCCESS;
-}
-
 enum exfat_resize_error exfat_resize_checked_ceil_divide_u64(
     uint64_t dividend, uint64_t divisor, uint64_t *result)
 {

--- a/lib/checked_math.h
+++ b/lib/checked_math.h
@@ -7,12 +7,6 @@
 
 #include <stdint.h>
 
-enum exfat_resize_error exfat_resize_checked_add_u64(
-    uint64_t left, uint64_t right, uint64_t *result);
-
-enum exfat_resize_error exfat_resize_checked_multiply_u64(
-    uint64_t left, uint64_t right, uint64_t *result);
-
 enum exfat_resize_error exfat_resize_checked_ceil_divide_u64(
     uint64_t dividend, uint64_t divisor, uint64_t *result);
 

--- a/lib/resize.c
+++ b/lib/resize.c
@@ -234,17 +234,11 @@ static enum exfat_resize_error cluster_sector(
 {
 	uint64_t cluster_offset;
 	uint64_t result;
-	enum exfat_resize_error error;
 
 	if (cluster < 2 || cluster > geometry->cluster_count + UINT32_C(1))
 		return EXFAT_RESIZE_OUT_OF_BOUNDS;
-	error = exfat_resize_checked_multiply_u64(
-	    (uint64_t)cluster - 2, geometry->sectors_per_cluster, &cluster_offset);
-	if (error != EXFAT_RESIZE_SUCCESS)
-		return error;
-	error = exfat_resize_checked_add_u64(geometry->cluster_heap_offset, cluster_offset, &result);
-	if (error != EXFAT_RESIZE_SUCCESS)
-		return error;
+	cluster_offset = ((uint64_t)cluster - 2) * geometry->sectors_per_cluster;
+	result = geometry->cluster_heap_offset + cluster_offset;
 	if (result >= geometry->volume_sector_count)
 		return EXFAT_RESIZE_OUT_OF_BOUNDS;
 	*sector = result;
@@ -263,7 +257,6 @@ static int cluster_is_valid(const struct exfat_resize_geometry *geometry, uint32
 
 static enum exfat_resize_error load_source_fat(struct resize_context *context)
 {
-	enum exfat_resize_error error;
 	uint64_t allocation_size;
 	uint32_t sector_count;
 
@@ -271,9 +264,7 @@ static enum exfat_resize_error load_source_fat(struct resize_context *context)
 	    exfat_resize_used_fat_sector_count(context->source.cluster_count, context->sector_size);
 	if (sector_count > context->source.fat_length)
 		return EXFAT_RESIZE_INVALID_FILESYSTEM;
-	error = exfat_resize_checked_multiply_u64(sector_count, context->sector_size, &allocation_size);
-	if (error != EXFAT_RESIZE_SUCCESS)
-		return error;
+	allocation_size = (uint64_t)sector_count * context->sector_size;
 	context->source_fat_size = (size_t)allocation_size;
 	if (context->source_fat_size != allocation_size)
 		return EXFAT_RESIZE_ARITHMETIC_OVERFLOW;
@@ -1613,10 +1604,8 @@ static enum exfat_resize_error prepare_context(struct resize_context *context,
 	error = validate_reserved_fat_entries(context);
 	if (error != EXFAT_RESIZE_SUCCESS)
 		return error;
-	error = exfat_resize_checked_multiply_u64(
-	    context->source.sectors_per_cluster, context->sector_size, &context->cluster_size);
-	if (error != EXFAT_RESIZE_SUCCESS)
-		return error;
+	context->cluster_size =
+	    (uint64_t)context->source.sectors_per_cluster * context->sector_size;
 
 	heap_movement =
 	    (uint64_t)context->target.cluster_heap_offset - context->source.cluster_heap_offset;

--- a/tests/library/unit/foundation_tests.c
+++ b/tests/library/unit/foundation_tests.c
@@ -22,24 +22,10 @@ static int failure_count;
 		} \
 	} while (0)
 
-static void test_checked_math(void)
+static void test_checked_ceil_divide(void)
 {
 	enum exfat_resize_error error;
 	uint64_t result;
-
-	error = exfat_resize_checked_add_u64(20, 22, &result);
-	CHECK(error == EXFAT_RESIZE_SUCCESS);
-	CHECK(result == 42);
-
-	error = exfat_resize_checked_add_u64(UINT64_MAX, 1, &result);
-	CHECK(error == EXFAT_RESIZE_ARITHMETIC_OVERFLOW);
-
-	error = exfat_resize_checked_multiply_u64(6, 7, &result);
-	CHECK(error == EXFAT_RESIZE_SUCCESS);
-	CHECK(result == 42);
-
-	error = exfat_resize_checked_multiply_u64(UINT64_MAX, 2, &result);
-	CHECK(error == EXFAT_RESIZE_ARITHMETIC_OVERFLOW);
 
 	error = exfat_resize_checked_ceil_divide_u64(9, 4, &result);
 	CHECK(error == EXFAT_RESIZE_SUCCESS);
@@ -56,7 +42,7 @@ static void test_checked_math(void)
 	error = exfat_resize_checked_ceil_divide_u64(1, 0, &result);
 	CHECK(error == EXFAT_RESIZE_INVALID_ARGUMENT);
 
-	error = exfat_resize_checked_add_u64(1, 2, NULL);
+	error = exfat_resize_checked_ceil_divide_u64(1, 1, NULL);
 	CHECK(error == EXFAT_RESIZE_INVALID_ARGUMENT);
 }
 
@@ -468,7 +454,7 @@ static void test_sparse_large_device(void)
 
 int main(void)
 {
-	test_checked_math();
+	test_checked_ceil_divide();
 	test_allocator_tracking();
 	test_allocator_failure_injection();
 	test_allocator_contract_errors();


### PR DESCRIPTION
Replace unreachable checked add and multiply paths with widened arithmetic. Retain checked ceiling division and FAT allocation narrowing validation.