### PR TITLE
Move partition growth guidance into dedicated document

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ foreach(exfat_resize_document_component IN ITEMS Runtime Development)
 
     install(
         FILES
+            docs/PARTITIONING.md
             docs/TRANSACTION.md
         DESTINATION
             ${CMAKE_INSTALL_DOCDIR}/docs

--- a/README.md
+++ b/README.md
@@ -152,8 +152,10 @@ to use all available space:
     truncate -s +2G image.exfat
     exfat-resize image.exfat
 
-After enlarging the partition or other backing storage with the appropriate
-platform tool, grow the filesystem on an unmounted raw device:
+First enlarge the partition or other backing storage with the appropriate
+platform tool. See [Partition growth outside
+`exfat-resize`](docs/PARTITIONING.md) for starting points. Then grow the
+filesystem on an unmounted raw device:
 
     exfat-resize /dev/your-exfat-device
 
@@ -217,6 +219,11 @@ requires:
 - A basic GPT or MBR data partition with no overlapping layout entry.
 - Enough unallocated space immediately after the partition.
 
+Other layouts require enlarging the containing partition separately before
+running `exfat-resize`. See [Partition growth outside
+`exfat-resize`](docs/PARTITIONING.md) for external tools and rescue
+environments.
+
 Before changing the partition table, the CLI validates both exFAT boot regions,
 checks that the filesystem can grow to the requested size, and verifies the
 volume-to-disk mapping and physical partition layout. It then uses Windows'
@@ -229,31 +236,6 @@ larger partition; do not shrink the partition. Correct the reported problem
 and retry the filesystem resize. Without `--grow-partition`, the CLI never
 changes a partition table.
 
-For a layout that this mode does not support, one open-source alternative is to
-boot [GParted Live][gparted-live], identify the whole target disk carefully, and
-use the included terminal rather than GParted's graphical exFAT resize action:
-
-```text
-sudo parted /dev/sdX
-(parted) unit s
-(parted) print free
-(parted) resizepart PARTITION_NUMBER NEW_END_SECTOR
-(parted) quit
-```
-
-[GNU Parted documents][resizepart] that `resizepart` changes the partition end
-without modifying the filesystem. Record the start sector first, select only
-an end sector in the immediately following free extent, and verify afterwards
-that the start is unchanged. Do not use this procedure to shrink exFAT.
-
-Windows DiskPart is not a substitute: its [documented `extend`
-operation][diskpart-extend] automatically extends NTFS and fails without a
-partition change for other formatted filesystems. Do not rely on claims that it
-will silently extend only an exFAT partition.
-
-[diskpart-extend]: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/extend
-[gparted-live]: https://gparted.org/livecd.php
-[resizepart]: https://www.gnu.org/software/parted/manual/html_node/resizepart.html
 [windows-grow-partition]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntdddisk/ni-ntdddisk-ioctl_disk_grow_partition
 
 ## Filesystem compatibility
@@ -453,11 +435,11 @@ CLI from the extracted directory:
     cd exfat-resize-X.Y.Z-windows-x86_64
     .\exfat-resize.exe --version
 
-The archive also contains the license, this README, the contribution guide, and
-the resize-transaction documentation. Resizing an image file normally does not
-require elevation. To access a logical volume or grow its partition, open
-PowerShell or Command Prompt as Administrator and invoke the extracted
-executable as described under [Windows usage](#windows).
+The archive also contains the license, this README, the contribution guide,
+and the resize-transaction and partition-growth documentation. Resizing an
+image file normally does not require elevation. To access a logical volume or
+grow its partition, open PowerShell or Command Prompt as Administrator and
+invoke the extracted executable as described under [Windows usage](#windows).
 
 ## Contributing
 

--- a/docs/PARTITIONING.md
+++ b/docs/PARTITIONING.md
@@ -1,0 +1,65 @@
+# Partition growth outside exfat-resize
+
+`exfat-resize` is focused on growing exFAT filesystems correctly, not on
+general disk partitioning. The one exception is the Windows-only
+[`--grow-partition`](../README.md#growing-the-containing-partition) option,
+which covers the common case of a basic GPT or MBR partition followed by enough
+unallocated space. Apart from that explicit option, `exfat-resize` never
+changes a partition table.
+
+When the containing partition is too small, enlarge it first with a suitable
+partitioning tool, then run `exfat-resize`. The following are starting points,
+not a partitioning guide. Make a verified backup, keep the exFAT filesystem
+unmounted, never move its start sector, and never shrink it.
+
+## growpart
+
+[`growpart`][growpart] extends one partition to the end of the disk or the
+beginning of the next partition. It supports a dry run:
+
+```text
+sudo growpart --dry-run /dev/sdX PARTITION_NUMBER
+sudo growpart /dev/sdX PARTITION_NUMBER
+```
+
+Verify the resulting partition layout before running `exfat-resize`.
+
+## GParted Live
+
+[GParted Live][gparted-live] is available for x86-64 computers. Identify the
+whole target disk carefully and use the included terminal rather than
+GParted's graphical exFAT resize action:
+
+```text
+sudo parted /dev/sdX
+(parted) unit s
+(parted) print free
+(parted) resizepart PARTITION_NUMBER NEW_END_SECTOR
+(parted) quit
+```
+
+[GNU Parted documents][resizepart] that `resizepart` changes the partition end
+without modifying the filesystem. Select only an end sector in the immediately
+following free extent and verify afterwards that the start is unchanged.
+
+## Other architectures
+
+For other architectures, use a GNU/Linux installer or rescue image built for
+the target hardware. [Debian installer rescue mode][debian-rescue] and
+[Ubuntu Server alternative-architecture images][ubuntu-server] are starting
+points. Use an available partitioning utility from its shell, or attach the
+disk to another supported computer. Confirm that the selected image boots the
+hardware and provides the required utility before relying on it.
+
+## Windows DiskPart
+
+Windows DiskPart is not a substitute: its [documented `extend`
+operation][diskpart-extend] automatically extends NTFS and fails without a
+partition change for other formatted filesystems.
+
+[debian-rescue]: https://www.debian.org/releases/stable/installmanual
+[diskpart-extend]: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/extend
+[gparted-live]: https://gparted.org/livecd.php
+[growpart]: https://github.com/canonical/cloud-utils
+[resizepart]: https://www.gnu.org/software/parted/manual/html_node/resizepart.html
+[ubuntu-server]: https://ubuntu.com/download/server

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -31,6 +31,8 @@ install -m 0644 "$archive_directory/CONTRIBUTING.md" \
 	"$install_root/share/doc/exfat-resize/CONTRIBUTING.md"
 install -m 0644 "$archive_directory/LICENSE" "$install_root/share/doc/exfat-resize/LICENSE"
 install -m 0644 "$archive_directory/README.md" "$install_root/share/doc/exfat-resize/README.md"
+install -m 0644 "$archive_directory/docs/PARTITIONING.md" \
+	"$install_root/share/doc/exfat-resize/docs/PARTITIONING.md"
 install -m 0644 "$archive_directory/docs/TRANSACTION.md" \
 	"$install_root/share/doc/exfat-resize/docs/TRANSACTION.md"
 

--- a/packaging/linux/uninstall.sh
+++ b/packaging/linux/uninstall.sh
@@ -26,6 +26,7 @@ rm -f "$install_root/bin/exfat-resize" "$install_root/share/man/man8/exfat-resiz
 	"$install_root/share/doc/exfat-resize/CONTRIBUTING.md" \
 	"$install_root/share/doc/exfat-resize/LICENSE" \
 	"$install_root/share/doc/exfat-resize/README.md" \
+	"$install_root/share/doc/exfat-resize/docs/PARTITIONING.md" \
 	"$install_root/share/doc/exfat-resize/docs/TRANSACTION.md"
 rmdir "$install_root/share/doc/exfat-resize/docs" 2>/dev/null || true
 rmdir "$install_root/share/doc/exfat-resize" 2>/dev/null || true

--- a/tests/package/install_test.cmake.in
+++ b/tests/package/install_test.cmake.in
@@ -21,6 +21,7 @@ set(documentation_dir "${install_prefix}/@CMAKE_INSTALL_DOCDIR@")
 set(contributing "${documentation_dir}/CONTRIBUTING.md")
 set(readme "${documentation_dir}/README.md")
 set(license "${documentation_dir}/LICENSE")
+set(partitioning_document "${documentation_dir}/docs/PARTITIONING.md")
 set(transaction_document "${documentation_dir}/docs/TRANSACTION.md")
 set(development_install_prefix "@CMAKE_CURRENT_BINARY_DIR@/development-install-tree")
 set(development_documentation_dir
@@ -63,6 +64,7 @@ foreach(required_file
         "${contributing}"
         "${readme}"
         "${license}"
+        "${partitioning_document}"
         "${transaction_document}"
 )
     if(NOT EXISTS "${required_file}")
@@ -103,6 +105,7 @@ foreach(required_file
         "${development_documentation_dir}/CONTRIBUTING.md"
         "${development_documentation_dir}/README.md"
         "${development_documentation_dir}/LICENSE"
+        "${development_documentation_dir}/docs/PARTITIONING.md"
         "${development_documentation_dir}/docs/TRANSACTION.md"
 )
     if(NOT EXISTS "${required_file}")
@@ -175,6 +178,7 @@ foreach(required_text
         "exfat-resize --grow-partition device size"
         "Conform to exFAT revision 1.00"
         "Vendor Allocation directory entries"
+        "docs/PARTITIONING.md"
         "docs/TRANSACTION.md#memory-requirements"
         "allocator-backed working-memory sizes"
         "ordinary heap memory"
@@ -195,6 +199,29 @@ foreach(readme_link IN LISTS readme_links)
     if(NOT EXISTS "${documentation_dir}/${link_path}")
         message(FATAL_ERROR
             "Installed README link does not resolve: ${link_target}"
+        )
+    endif()
+endforeach()
+
+file(READ "${partitioning_document}" partitioning_contents)
+foreach(required_text
+        "# Partition growth outside exfat-resize"
+        "focused on growing exFAT filesystems correctly"
+        "Apart from that explicit option"
+        "## growpart"
+        "growpart --dry-run /dev/sdX PARTITION_NUMBER"
+        "## GParted Live"
+        "resizepart PARTITION_NUMBER NEW_END_SECTOR"
+        "## Other architectures"
+        "Debian installer rescue mode"
+        "Ubuntu Server alternative-architecture images"
+        "## Windows DiskPart"
+        "Windows DiskPart is not a substitute"
+)
+    string(FIND "${partitioning_contents}" "${required_text}" required_text_offset)
+    if(required_text_offset EQUAL -1)
+        message(FATAL_ERROR
+            "Installed partitioning document does not contain: ${required_text}"
         )
     endif()
 endforeach()

--- a/tests/package/linux-binary-test.sh
+++ b/tests/package/linux-binary-test.sh
@@ -56,8 +56,9 @@ if [ "$actual" != "$expected" ]; then
 	printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
 	exit 1
 fi
-documentation=$(find "$package_directory/docs" -mindepth 1 -maxdepth 1 -printf '%f\n')
-if [ "$documentation" != TRANSACTION.md ]; then
+expected_documentation=$(printf '%s\n' PARTITIONING.md TRANSACTION.md | sort)
+documentation=$(find "$package_directory/docs" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)
+if [ "$documentation" != "$expected_documentation" ]; then
 	echo "Linux archive contains an unexpected documentation file set" >&2
 	exit 1
 fi
@@ -71,6 +72,7 @@ if [ "$(stat -c '%a' "$package_directory/exfat-resize.8")" != 644 ] ||
 	[ "$(stat -c '%a' "$package_directory/CONTRIBUTING.md")" != 644 ] ||
 	[ "$(stat -c '%a' "$package_directory/LICENSE")" != 644 ] ||
 	[ "$(stat -c '%a' "$package_directory/README.md")" != 644 ] ||
+	[ "$(stat -c '%a' "$package_directory/docs/PARTITIONING.md")" != 644 ] ||
 	[ "$(stat -c '%a' "$package_directory/docs/TRANSACTION.md")" != 644 ]; then
 	echo "Linux archive data-file modes are incorrect" >&2
 	exit 1
@@ -86,6 +88,7 @@ fi
 cmp "$source_directory/CONTRIBUTING.md" "$package_directory/CONTRIBUTING.md"
 cmp "$source_directory/LICENSE" "$package_directory/LICENSE"
 cmp "$source_directory/README.md" "$package_directory/README.md"
+cmp "$source_directory/docs/PARTITIONING.md" "$package_directory/docs/PARTITIONING.md"
 cmp "$source_directory/docs/TRANSACTION.md" "$package_directory/docs/TRANSACTION.md"
 
 DESTDIR=$temporary/install-root "$package_directory/install.sh"
@@ -95,15 +98,16 @@ installed_manual=$install_prefix/share/man/man8/exfat-resize.8
 installed_contributing=$install_prefix/share/doc/exfat-resize/CONTRIBUTING.md
 installed_license=$install_prefix/share/doc/exfat-resize/LICENSE
 installed_readme=$install_prefix/share/doc/exfat-resize/README.md
+installed_partitioning=$install_prefix/share/doc/exfat-resize/docs/PARTITIONING.md
 installed_transaction=$install_prefix/share/doc/exfat-resize/docs/TRANSACTION.md
 if [ "$("$installed_binary" --version)" != "exfat-resize $build_version" ] ||
 	[ ! -f "$installed_manual" ] || [ ! -f "$installed_license" ] ||
 	[ ! -f "$installed_contributing" ] || [ ! -f "$installed_readme" ] ||
-	[ ! -f "$installed_transaction" ]; then
+	[ ! -f "$installed_partitioning" ] || [ ! -f "$installed_transaction" ]; then
 	echo "installed Linux archive is incomplete" >&2
 	exit 1
 fi
-if [ "$(find "$install_prefix" -type f | wc -l)" -ne 6 ]; then
+if [ "$(find "$install_prefix" -type f | wc -l)" -ne 7 ]; then
 	echo "installer created an unexpected file set" >&2
 	exit 1
 fi
@@ -114,7 +118,7 @@ touch "$install_prefix/bin/unrelated" "$install_prefix/share/man/man8/unrelated.
 DESTDIR=$temporary/install-root "$package_directory/uninstall.sh"
 if [ -e "$installed_binary" ] || [ -e "$installed_manual" ] || [ -e "$installed_license" ] ||
 	[ -e "$installed_contributing" ] || [ -e "$installed_readme" ] ||
-	[ -e "$installed_transaction" ]; then
+	[ -e "$installed_partitioning" ] || [ -e "$installed_transaction" ]; then
 	echo "uninstaller left an installed project file behind" >&2
 	exit 1
 fi

--- a/tests/package/macos-binary-test.sh
+++ b/tests/package/macos-binary-test.sh
@@ -75,6 +75,7 @@ expected_entries=$(
 		"$package/LICENSE" \
 		"$package/README.md" \
 		"$package/docs/" \
+		"$package/docs/PARTITIONING.md" \
 		"$package/docs/TRANSACTION.md" \
 		"$package/exfat-resize" \
 		"$package/exfat-resize.8" \
@@ -113,8 +114,9 @@ if [ "$actual" != "$expected" ]; then
 	printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
 	exit 1
 fi
-documentation=$(find "$package_directory/docs" -mindepth 1 -maxdepth 1 -exec basename {} \;)
-if [ "$documentation" != TRANSACTION.md ]; then
+expected_documentation=$(printf '%s\n' PARTITIONING.md TRANSACTION.md | sort)
+documentation=$(find "$package_directory/docs" -mindepth 1 -maxdepth 1 -exec basename {} \; | sort)
+if [ "$documentation" != "$expected_documentation" ]; then
 	echo "macOS archive contains an unexpected documentation file set" >&2
 	exit 1
 fi
@@ -128,6 +130,7 @@ if [ "$(stat -f '%Lp' "$package_directory/exfat-resize.8")" != 644 ] ||
 	[ "$(stat -f '%Lp' "$package_directory/CONTRIBUTING.md")" != 644 ] ||
 	[ "$(stat -f '%Lp' "$package_directory/LICENSE")" != 644 ] ||
 	[ "$(stat -f '%Lp' "$package_directory/README.md")" != 644 ] ||
+	[ "$(stat -f '%Lp' "$package_directory/docs/PARTITIONING.md")" != 644 ] ||
 	[ "$(stat -f '%Lp' "$package_directory/docs/TRANSACTION.md")" != 644 ]; then
 	echo "macOS archive data-file modes are incorrect" >&2
 	exit 1
@@ -145,6 +148,7 @@ fi
 cmp "$source_directory/CONTRIBUTING.md" "$package_directory/CONTRIBUTING.md"
 cmp "$source_directory/LICENSE" "$package_directory/LICENSE"
 cmp "$source_directory/README.md" "$package_directory/README.md"
+cmp "$source_directory/docs/PARTITIONING.md" "$package_directory/docs/PARTITIONING.md"
 cmp "$source_directory/docs/TRANSACTION.md" "$package_directory/docs/TRANSACTION.md"
 
 architectures=$(lipo -archs "$binary")
@@ -214,15 +218,16 @@ installed_manual=$install_prefix/share/man/man8/exfat-resize.8
 installed_contributing=$install_prefix/share/doc/exfat-resize/CONTRIBUTING.md
 installed_license=$install_prefix/share/doc/exfat-resize/LICENSE
 installed_readme=$install_prefix/share/doc/exfat-resize/README.md
+installed_partitioning=$install_prefix/share/doc/exfat-resize/docs/PARTITIONING.md
 installed_transaction=$install_prefix/share/doc/exfat-resize/docs/TRANSACTION.md
 if [ "$("$installed_binary" --version)" != "exfat-resize $build_version" ] ||
 	[ ! -f "$installed_manual" ] || [ ! -f "$installed_license" ] ||
 	[ ! -f "$installed_contributing" ] || [ ! -f "$installed_readme" ] ||
-	[ ! -f "$installed_transaction" ]; then
+	[ ! -f "$installed_partitioning" ] || [ ! -f "$installed_transaction" ]; then
 	echo "installed macOS archive is incomplete" >&2
 	exit 1
 fi
-if [ "$(find "$install_prefix" -type f | wc -l)" -ne 6 ]; then
+if [ "$(find "$install_prefix" -type f | wc -l)" -ne 7 ]; then
 	echo "installer created an unexpected file set" >&2
 	exit 1
 fi
@@ -240,7 +245,7 @@ touch "$install_prefix/bin/unrelated" "$install_prefix/share/man/man8/unrelated.
 DESTDIR=$temporary/install-root "$package_directory/uninstall.sh"
 if [ -e "$installed_binary" ] || [ -e "$installed_manual" ] || [ -e "$installed_license" ] ||
 	[ -e "$installed_contributing" ] || [ -e "$installed_readme" ] ||
-	[ -e "$installed_transaction" ]; then
+	[ -e "$installed_partitioning" ] || [ -e "$installed_transaction" ]; then
 	echo "uninstaller left an installed project file behind" >&2
 	exit 1
 fi

--- a/tests/package/windows-binary-test.ps1
+++ b/tests/package/windows-binary-test.ps1
@@ -88,6 +88,7 @@ try {
     $Expected = @(
         "CONTRIBUTING.md",
         "docs",
+        "docs/PARTITIONING.md",
         "docs/TRANSACTION.md",
         "exfat-resize.exe",
         "LICENSE",
@@ -109,6 +110,8 @@ try {
         (Join-Path $PackageDirectory "LICENSE")
     Assert-SameFile (Join-Path $SourceDirectory "README.md") `
         (Join-Path $PackageDirectory "README.md")
+    Assert-SameFile (Join-Path $SourceDirectory "docs/PARTITIONING.md") `
+        (Join-Path $PackageDirectory "docs/PARTITIONING.md")
     Assert-SameFile (Join-Path $SourceDirectory "docs/TRANSACTION.md") `
         (Join-Path $PackageDirectory "docs/TRANSACTION.md")
 

--- a/tools/build-linux-binary.sh
+++ b/tools/build-linux-binary.sh
@@ -73,9 +73,11 @@ documentation=$temporary/stage/usr/local/share/doc/exfat_resize
 contributing=$documentation/CONTRIBUTING.md
 license=$documentation/LICENSE
 readme=$documentation/README.md
+partitioning=$documentation/docs/PARTITIONING.md
 transaction=$documentation/docs/TRANSACTION.md
 if [ ! -x "$binary" ] || [ ! -f "$manual" ] || [ ! -f "$license" ] ||
-	[ ! -f "$contributing" ] || [ ! -f "$readme" ] || [ ! -f "$transaction" ]; then
+	[ ! -f "$contributing" ] || [ ! -f "$readme" ] || [ ! -f "$partitioning" ] ||
+	[ ! -f "$transaction" ]; then
 	echo "CMake runtime installation is incomplete" >&2
 	exit 1
 fi
@@ -115,6 +117,7 @@ install -m 0644 "$manual" "$package_directory/exfat-resize.8"
 install -m 0644 "$contributing" "$package_directory/CONTRIBUTING.md"
 install -m 0644 "$license" "$package_directory/LICENSE"
 install -m 0644 "$readme" "$package_directory/README.md"
+install -m 0644 "$partitioning" "$package_directory/docs/PARTITIONING.md"
 install -m 0644 "$transaction" "$package_directory/docs/TRANSACTION.md"
 install -m 0755 "$source_directory/packaging/linux/install.sh" "$package_directory/install.sh"
 install -m 0755 "$source_directory/packaging/linux/uninstall.sh" "$package_directory/uninstall.sh"

--- a/tools/build-macos-binary.sh
+++ b/tools/build-macos-binary.sh
@@ -78,9 +78,11 @@ documentation=$temporary/stage/usr/local/share/doc/exfat_resize
 contributing=$documentation/CONTRIBUTING.md
 license=$documentation/LICENSE
 readme=$documentation/README.md
+partitioning=$documentation/docs/PARTITIONING.md
 transaction=$documentation/docs/TRANSACTION.md
 if [ ! -x "$binary" ] || [ ! -f "$manual" ] || [ ! -f "$license" ] ||
-	[ ! -f "$contributing" ] || [ ! -f "$readme" ] || [ ! -f "$transaction" ]; then
+	[ ! -f "$contributing" ] || [ ! -f "$readme" ] || [ ! -f "$partitioning" ] ||
+	[ ! -f "$transaction" ]; then
 	echo "CMake runtime installation is incomplete" >&2
 	exit 1
 fi
@@ -126,6 +128,7 @@ install -m 0644 "$manual" "$package_directory/exfat-resize.8"
 install -m 0644 "$contributing" "$package_directory/CONTRIBUTING.md"
 install -m 0644 "$license" "$package_directory/LICENSE"
 install -m 0644 "$readme" "$package_directory/README.md"
+install -m 0644 "$partitioning" "$package_directory/docs/PARTITIONING.md"
 install -m 0644 "$transaction" "$package_directory/docs/TRANSACTION.md"
 install -m 0755 "$source_directory/packaging/linux/install.sh" "$package_directory/install.sh"
 install -m 0755 "$source_directory/packaging/linux/uninstall.sh" \

--- a/tools/build-windows-binary.ps1
+++ b/tools/build-windows-binary.ps1
@@ -91,8 +91,11 @@ try {
     $Contributing = Join-Path $Documentation "CONTRIBUTING.md"
     $License = Join-Path $Documentation "LICENSE"
     $Readme = Join-Path $Documentation "README.md"
+    $Partitioning = Join-Path $Documentation "docs/PARTITIONING.md"
     $Transaction = Join-Path $Documentation "docs/TRANSACTION.md"
-    foreach ($RequiredFile in @($Binary, $Contributing, $License, $Readme, $Transaction)) {
+    foreach ($RequiredFile in @(
+        $Binary, $Contributing, $License, $Readme, $Partitioning, $Transaction
+    )) {
         if (-not (Test-Path -LiteralPath $RequiredFile -PathType Leaf)) {
             throw "CMake runtime installation is incomplete: $RequiredFile"
         }
@@ -109,6 +112,7 @@ try {
     Copy-Item -LiteralPath $Contributing -Destination $PackageDirectory
     Copy-Item -LiteralPath $License -Destination $PackageDirectory
     Copy-Item -LiteralPath $Readme -Destination $PackageDirectory
+    Copy-Item -LiteralPath $Partitioning -Destination $PackageDocumentation
     Copy-Item -LiteralPath $Transaction -Destination $PackageDocumentation
 
     $Archive = Join-Path $OutputDirectory "$Package.zip"


### PR DESCRIPTION
Add focused pointers for growpart, GParted Live, rescue media, and DiskPart while keeping README usage concise. Package and verify the new partitioning document on every supported platform.